### PR TITLE
#602 [PR 4] 设计系统与原子组件库 (渐进式双主题架构)

### DIFF
--- a/apps/dsa-web/package-lock.json
+++ b/apps/dsa-web/package-lock.json
@@ -10,11 +10,13 @@
       "dependencies": {
         "axios": "^1.13.4",
         "camelcase-keys": "^10.0.2",
+        "clsx": "^2.1.1",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.13.0",
         "remark-gfm": "^4.0.1",
+        "tailwind-merge": "^3.5.0",
         "zustand": "^5.0.11"
       },
       "devDependencies": {
@@ -2436,6 +2438,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmmirror.com/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -5383,6 +5394,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmmirror.com/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
+      "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/apps/dsa-web/package.json
+++ b/apps/dsa-web/package.json
@@ -12,11 +12,13 @@
   "dependencies": {
     "axios": "^1.13.4",
     "camelcase-keys": "^10.0.2",
+    "clsx": "^2.1.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.13.0",
     "remark-gfm": "^4.0.1",
+    "tailwind-merge": "^3.5.0",
     "zustand": "^5.0.11"
   },
   "devDependencies": {

--- a/apps/dsa-web/src/components/common/AppPage.tsx
+++ b/apps/dsa-web/src/components/common/AppPage.tsx
@@ -1,0 +1,15 @@
+import type React from 'react';
+import { cn } from '../../utils/cn';
+
+interface AppPageProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const AppPage: React.FC<AppPageProps> = ({ children, className = '' }) => {
+  return (
+    <main className={cn('mx-auto min-h-screen w-full max-w-7xl px-4 pb-8 pt-4 md:px-6 lg:px-8', className)}>
+      {children}
+    </main>
+  );
+};

--- a/apps/dsa-web/src/components/common/Badge.tsx
+++ b/apps/dsa-web/src/components/common/Badge.tsx
@@ -12,12 +12,12 @@ interface BadgeProps {
 }
 
 const variantStyles: Record<BadgeVariant, string> = {
-  default: 'border-white/10 bg-white/5 text-secondary',
+  default: 'border-border/40 bg-elevated/40 text-secondary-text',
   success: 'border-success/20 bg-success/10 text-success',
   warning: 'border-warning/20 bg-warning/10 text-warning',
   danger: 'border-danger/20 bg-danger/10 text-danger',
   info: 'border-cyan/20 bg-cyan/10 text-cyan',
-  history: 'border-purple/20 bg-purple/10 text-violet-200',
+  history: 'border-purple/20 bg-purple/10 text-purple',
 };
 
 const glowStyles: Record<BadgeVariant, string> = {
@@ -25,8 +25,8 @@ const glowStyles: Record<BadgeVariant, string> = {
   success: 'shadow-success/20',
   warning: 'shadow-warning/20',
   danger: 'shadow-danger/20',
-  info: 'shadow-cyan-500/20',
-  history: 'shadow-purple-500/20',
+  info: 'shadow-cyan/20',
+  history: 'shadow-purple/20',
 };
 
 /**

--- a/apps/dsa-web/src/components/common/Badge.tsx
+++ b/apps/dsa-web/src/components/common/Badge.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { cn } from '../../utils/cn';
 
 type BadgeVariant = 'default' | 'success' | 'warning' | 'danger' | 'info' | 'history';
 
@@ -11,26 +12,25 @@ interface BadgeProps {
 }
 
 const variantStyles: Record<BadgeVariant, string> = {
-  default: 'bg-slate-700/50 text-gray-300 border-slate-600/50',
-  success: 'bg-emerald-500/20 text-emerald-400 border-emerald-500/30',
-  warning: 'bg-amber-500/20 text-amber-400 border-amber-500/30',
-  danger: 'bg-red-500/20 text-red-400 border-red-500/30',
-  info: 'bg-cyan-500/20 text-cyan-400 border-cyan-500/30',
-  history: 'bg-purple-500/20 text-purple-400 border-purple-500/30',
+  default: 'border-white/10 bg-white/5 text-secondary',
+  success: 'border-success/20 bg-success/10 text-success',
+  warning: 'border-warning/20 bg-warning/10 text-warning',
+  danger: 'border-danger/20 bg-danger/10 text-danger',
+  info: 'border-cyan/20 bg-cyan/10 text-cyan',
+  history: 'border-purple/20 bg-purple/10 text-violet-200',
 };
 
 const glowStyles: Record<BadgeVariant, string> = {
   default: '',
-  success: 'shadow-emerald-500/20',
-  warning: 'shadow-amber-500/20',
-  danger: 'shadow-red-500/20',
+  success: 'shadow-success/20',
+  warning: 'shadow-warning/20',
+  danger: 'shadow-danger/20',
   info: 'shadow-cyan-500/20',
   history: 'shadow-purple-500/20',
 };
 
 /**
- * 标签徽章组件
- * 支持多种变体和发光效果
+ * Badge component with multiple variants and optional glow styling.
  */
 export const Badge: React.FC<BadgeProps> = ({
   children,
@@ -43,14 +43,13 @@ export const Badge: React.FC<BadgeProps> = ({
 
   return (
     <span
-      className={`
-        inline-flex items-center gap-1 rounded-full font-medium
-        border backdrop-blur-sm
-        ${sizeStyles}
-        ${variantStyles[variant]}
-        ${glow ? `shadow-lg ${glowStyles[variant]}` : ''}
-        ${className}
-      `}
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full border font-medium backdrop-blur-sm',
+        sizeStyles,
+        variantStyles[variant],
+        glow && `shadow-lg ${glowStyles[variant]}`,
+        className,
+      )}
     >
       {children}
     </span>

--- a/apps/dsa-web/src/components/common/Button.tsx
+++ b/apps/dsa-web/src/components/common/Button.tsx
@@ -21,7 +21,7 @@ const BUTTON_VARIANT_STYLES = {
   primary: 'border border-cyan/30 bg-cyan text-slate-950 shadow-lg shadow-cyan/20 hover:brightness-105',
   secondary: 'border border-white/10 bg-card text-foreground shadow-soft-card hover:bg-hover',
   outline: 'border border-cyan/25 bg-transparent text-cyan hover:bg-cyan/10',
-  ghost: 'border border-transparent bg-transparent text-secondary hover:bg-white/5 hover:text-foreground',
+  ghost: 'border border-transparent bg-transparent text-secondary-text hover:bg-white/5 hover:text-foreground',
   gradient: 'border border-cyan/20 bg-gradient-to-r from-cyan to-purple text-white shadow-lg shadow-cyan/20 hover:brightness-105',
   danger: 'border border-danger/40 bg-danger text-white shadow-lg shadow-danger/20 hover:brightness-105',
 } as const;

--- a/apps/dsa-web/src/components/common/Button.tsx
+++ b/apps/dsa-web/src/components/common/Button.tsx
@@ -1,98 +1,65 @@
 import React from 'react';
+import { cn } from '../../utils/cn';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: 'primary' | 'secondary' | 'outline' | 'ghost' | 'gradient' | 'danger';
-  size?: 'sm' | 'md' | 'lg';
+  size?: 'sm' | 'md' | 'lg' | 'xl';
   isLoading?: boolean;
+  /** Custom loading text. */
+  loadingText?: string;
   glow?: boolean;
 }
 
+const BUTTON_SIZE_STYLES = {
+  sm: 'h-9 rounded-lg px-3 text-sm',
+  md: 'h-10 rounded-xl px-4 text-sm',
+  lg: 'h-11 rounded-xl px-5 text-sm',
+  xl: 'h-12 rounded-xl px-6 text-sm',
+} as const;
+
+const BUTTON_VARIANT_STYLES = {
+  primary: 'border border-cyan/30 bg-cyan text-slate-950 shadow-lg shadow-cyan/20 hover:brightness-105',
+  secondary: 'border border-white/10 bg-card text-foreground shadow-soft-card hover:bg-hover',
+  outline: 'border border-cyan/25 bg-transparent text-cyan hover:bg-cyan/10',
+  ghost: 'border border-transparent bg-transparent text-secondary hover:bg-white/5 hover:text-foreground',
+  gradient: 'border border-cyan/20 bg-gradient-to-r from-cyan to-purple text-white shadow-lg shadow-cyan/20 hover:brightness-105',
+  danger: 'border border-danger/40 bg-danger text-white shadow-lg shadow-danger/20 hover:brightness-105',
+} as const;
+
 /**
- * 按钮组件
- * 支持多种变体和科技感样式
+ * Button component with multiple variants and terminal-inspired styling.
  */
 export const Button: React.FC<ButtonProps> = ({
   children,
   variant = 'primary',
   size = 'md',
   isLoading = false,
+  loadingText = '处理中...',
   glow = false,
   className = '',
   disabled,
   ...props
 }) => {
-  const baseStyle = `
-    inline-flex items-center justify-center
-    font-medium rounded-lg
-    transition-all duration-200
-    focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-900
-    disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none
-  `;
-
-  const sizeStyles = {
-    sm: 'px-3 py-1.5 text-sm',
-    md: 'px-4 py-2.5 text-sm',
-    lg: 'px-6 py-3 text-base',
-  };
-
-  const variantStyles = {
-    primary: `
-      bg-cyan-600 text-white
-      hover:bg-cyan-500
-      focus:ring-cyan-500
-      shadow-lg shadow-cyan-500/25
-    `,
-    secondary: `
-      bg-slate-700 text-gray-200
-      hover:bg-slate-600
-      focus:ring-slate-500
-      border border-slate-600
-    `,
-    outline: `
-      bg-transparent text-cyan-400
-      border border-cyan-500/30
-      hover:bg-cyan-500/10 hover:border-cyan-500/50
-      focus:ring-cyan-500
-    `,
-    ghost: `
-      bg-transparent text-gray-300
-      hover:bg-white/5 hover:text-white
-      focus:ring-gray-500
-    `,
-    gradient: `
-      bg-gradient-to-r from-cyan-500 to-blue-500 text-white
-      hover:from-cyan-400 hover:to-blue-400
-      focus:ring-cyan-500
-      shadow-lg shadow-cyan-500/25
-    `,
-    danger: `
-      bg-red-600 text-white
-      hover:bg-red-500
-      focus:ring-red-500
-      shadow-lg shadow-red-500/25
-    `,
-  };
-
-  const glowStyles = glow
-    ? 'shadow-glow-cyan hover:shadow-[0_0_30px_rgba(6,182,212,0.4)]'
-    : '';
+  const glowStyles = glow ? 'shadow-glow-cyan hover:shadow-[0_0_30px_rgba(0,212,255,0.38)]' : '';
 
   return (
     <button
-      className={`
-        ${baseStyle}
-        ${sizeStyles[size]}
-        ${variantStyles[variant]}
-        ${glowStyles}
-        ${className}
-      `}
+      className={cn(
+        'inline-flex items-center justify-center gap-2 font-medium transition-all duration-200',
+        'focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-cyan/15 focus-visible:ring-offset-0',
+        'disabled:pointer-events-none disabled:opacity-50 disabled:transform-none',
+        BUTTON_SIZE_STYLES[size],
+        BUTTON_VARIANT_STYLES[variant],
+        glowStyles,
+        className,
+      )}
       disabled={disabled || isLoading}
       {...props}
     >
       {isLoading ? (
-        <span className="flex items-center justify-center">
+        <span className="flex items-center justify-center gap-2">
           <svg
-            className="animate-spin -ml-1 mr-2 h-4 w-4 text-current"
+            className="h-4 w-4 animate-spin text-current"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"
@@ -111,7 +78,7 @@ export const Button: React.FC<ButtonProps> = ({
               d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
             />
           </svg>
-          处理中...
+          {loadingText}
         </span>
       ) : (
         children

--- a/apps/dsa-web/src/components/common/Card.tsx
+++ b/apps/dsa-web/src/components/common/Card.tsx
@@ -1,4 +1,5 @@
 import type React from 'react';
+import { cn } from '../../utils/cn';
 
 interface CardProps {
   title?: string;
@@ -11,8 +12,7 @@ interface CardProps {
 }
 
 /**
- * 终端风格卡片组件
- * 支持渐变边框、悬浮效果
+ * Card component with terminal-inspired variants and optional hover styling.
  */
 export const Card: React.FC<CardProps> = ({
   title,
@@ -25,12 +25,10 @@ export const Card: React.FC<CardProps> = ({
 }) => {
   const paddingStyles = {
     none: '',
-    sm: 'p-3',
-    md: 'p-4',
-    lg: 'p-5',
+    sm: 'p-4',
+    md: 'p-5',
+    lg: 'p-6',
   };
-
-  const baseStyles = 'rounded-2xl';
 
   const variantStyles = {
     default: 'terminal-card',
@@ -38,24 +36,16 @@ export const Card: React.FC<CardProps> = ({
     gradient: 'gradient-border-card',
   };
 
-  const hoverStyles = hoverable
-    ? 'terminal-card-hover cursor-pointer'
-    : '';
+  const hoverStyles = hoverable ? 'terminal-card-hover cursor-pointer' : '';
 
   if (variant === 'gradient') {
     return (
-      <div className={`${variantStyles.gradient} ${className}`}>
-        <div className={`gradient-border-card-inner ${paddingStyles[padding]}`}>
+      <div className={cn(variantStyles.gradient, className)}>
+        <div className={cn('gradient-border-card-inner', paddingStyles[padding])}>
           {(title || subtitle) && (
             <div className="mb-3">
-              {subtitle && (
-                <span className="label-uppercase">{subtitle}</span>
-              )}
-              {title && (
-                <h3 className="text-lg font-semibold text-white mt-1">
-                  {title}
-                </h3>
-              )}
+              {subtitle ? <span className="label-uppercase">{subtitle}</span> : null}
+              {title ? <h3 className="mt-1 text-lg font-semibold text-white">{title}</h3> : null}
             </div>
           )}
           {children}
@@ -66,24 +56,12 @@ export const Card: React.FC<CardProps> = ({
 
   return (
     <div
-      className={`
-        ${baseStyles}
-        ${variantStyles[variant]}
-        ${hoverStyles}
-        ${paddingStyles[padding]}
-        ${className}
-      `}
+      className={cn('rounded-2xl', variantStyles[variant], hoverStyles, paddingStyles[padding], className)}
     >
       {(title || subtitle) && (
         <div className="mb-3">
-          {subtitle && (
-            <span className="label-uppercase">{subtitle}</span>
-          )}
-          {title && (
-            <h3 className="text-lg font-semibold text-white mt-1">
-              {title}
-            </h3>
-          )}
+          {subtitle ? <span className="label-uppercase">{subtitle}</span> : null}
+          {title ? <h3 className="mt-1 text-lg font-semibold text-white">{title}</h3> : null}
         </div>
       )}
       {children}

--- a/apps/dsa-web/src/components/common/Collapsible.tsx
+++ b/apps/dsa-web/src/components/common/Collapsible.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { cn } from '../../utils/cn';
 
 interface CollapsibleProps {
   title: string;
@@ -9,8 +10,7 @@ interface CollapsibleProps {
 }
 
 /**
- * 可折叠面板组件
- * 支持动画展开/收起
+ * Collapsible panel with animated expand and collapse behavior.
  */
 export const Collapsible: React.FC<CollapsibleProps> = ({
   title,
@@ -23,28 +23,23 @@ export const Collapsible: React.FC<CollapsibleProps> = ({
 
   return (
     <div
-      className={`
-        rounded-xl overflow-hidden
-        bg-gradient-to-br from-slate-800/50 to-slate-900/50
-        border border-cyan-500/10 hover:border-cyan-500/20
-        transition-all duration-300
-        ${className}
-      `}
+      className={cn(
+        'overflow-hidden rounded-2xl border border-white/8 bg-card/70 shadow-soft-card transition-all duration-300',
+        'hover:border-cyan/20',
+        className,
+      )}
     >
-      {/* 标题栏 */}
       <button
+        type="button"
         onClick={() => setIsOpen(!isOpen)}
-        className="w-full flex items-center justify-between px-4 py-3 text-left
-          hover:bg-white/5 transition-colors"
+        className="flex w-full items-center justify-between px-4 py-3 text-left transition-colors hover:bg-white/5"
       >
         <div className="flex items-center gap-3">
           {icon && <span className="text-cyan-400">{icon}</span>}
-          <span className="font-medium text-gray-200">{title}</span>
+          <span className="font-medium text-gray-100">{title}</span>
         </div>
         <svg
-          className={`w-5 h-5 text-gray-400 transition-transform duration-300 ${
-            isOpen ? 'rotate-180' : ''
-          }`}
+          className={cn('h-5 w-5 text-secondary transition-transform duration-300', isOpen && 'rotate-180')}
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
@@ -53,14 +48,10 @@ export const Collapsible: React.FC<CollapsibleProps> = ({
         </svg>
       </button>
 
-      {/* 内容区 */}
       <div
-        className={`
-          overflow-hidden transition-all duration-300 ease-in-out
-          ${isOpen ? 'max-h-[2000px] opacity-100' : 'max-h-0 opacity-0'}
-        `}
+        className={cn('overflow-hidden transition-all duration-300 ease-in-out', isOpen ? 'max-h-[2000px] opacity-100' : 'max-h-0 opacity-0')}
       >
-        <div className="px-4 pb-4 pt-2 border-t border-cyan-500/10">
+        <div className="border-t border-white/8 px-4 pb-4 pt-2">
           {children}
         </div>
       </div>

--- a/apps/dsa-web/src/components/common/Collapsible.tsx
+++ b/apps/dsa-web/src/components/common/Collapsible.tsx
@@ -39,7 +39,7 @@ export const Collapsible: React.FC<CollapsibleProps> = ({
           <span className="font-medium text-gray-100">{title}</span>
         </div>
         <svg
-          className={cn('h-5 w-5 text-secondary transition-transform duration-300', isOpen && 'rotate-180')}
+          className={cn('h-5 w-5 text-secondary-text transition-transform duration-300', isOpen && 'rotate-180')}
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"

--- a/apps/dsa-web/src/components/common/Drawer.tsx
+++ b/apps/dsa-web/src/components/common/Drawer.tsx
@@ -2,6 +2,8 @@ import type React from 'react';
 import { useEffect, useCallback } from 'react';
 import { cn } from '../../utils/cn';
 
+let activeDrawerCount = 0;
+
 interface DrawerProps {
   isOpen: boolean;
   onClose: () => void;
@@ -35,12 +37,19 @@ export const Drawer: React.FC<DrawerProps> = ({
   useEffect(() => {
     if (isOpen) {
       document.addEventListener('keydown', handleKeyDown);
-      document.body.style.overflow = 'hidden';
+      activeDrawerCount++;
+      if (activeDrawerCount === 1) {
+        document.body.style.overflow = 'hidden';
+      }
+
+      return () => {
+        document.removeEventListener('keydown', handleKeyDown);
+        activeDrawerCount--;
+        if (activeDrawerCount === 0) {
+          document.body.style.overflow = '';
+        }
+      };
     }
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-      document.body.style.overflow = '';
-    };
   }, [isOpen, handleKeyDown]);
 
   if (!isOpen) return null;
@@ -49,7 +58,7 @@ export const Drawer: React.FC<DrawerProps> = ({
     <div className="fixed inset-0 overflow-hidden" style={{ zIndex }}>
       {/* Backdrop */}
       <div
-        className="absolute inset-0 bg-slate-950/72 backdrop-blur-sm transition-opacity duration-300"
+        className="absolute inset-0 bg-background/80 backdrop-blur-sm transition-opacity duration-300"
         onClick={onClose}
       />
 
@@ -67,7 +76,7 @@ export const Drawer: React.FC<DrawerProps> = ({
             <button
               type="button"
               onClick={onClose}
-              className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-white/10 bg-white/5 text-secondary transition-colors hover:bg-white/10 hover:text-white"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-white/10 bg-white/5 text-secondary-text transition-colors hover:bg-white/10 hover:text-white"
             >
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />

--- a/apps/dsa-web/src/components/common/Drawer.tsx
+++ b/apps/dsa-web/src/components/common/Drawer.tsx
@@ -1,5 +1,6 @@
 import type React from 'react';
 import { useEffect, useCallback } from 'react';
+import { cn } from '../../utils/cn';
 
 interface DrawerProps {
   isOpen: boolean;
@@ -11,7 +12,7 @@ interface DrawerProps {
 }
 
 /**
- * 侧滑抽屉组件 - 终端风格
+ * Side drawer component with terminal-inspired styling.
  */
 export const Drawer: React.FC<DrawerProps> = ({
   isOpen,
@@ -21,7 +22,7 @@ export const Drawer: React.FC<DrawerProps> = ({
   width = 'max-w-2xl',
   zIndex = 50,
 }) => {
-  // ESC 键关闭
+  // Close the drawer when Escape is pressed.
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
@@ -46,43 +47,33 @@ export const Drawer: React.FC<DrawerProps> = ({
 
   return (
     <div className="fixed inset-0 overflow-hidden" style={{ zIndex }}>
-      {/* 遮罩层 */}
+      {/* Backdrop */}
       <div
-        className="absolute inset-0 bg-black/70 backdrop-blur-sm transition-opacity duration-300"
+        className="absolute inset-0 bg-slate-950/72 backdrop-blur-sm transition-opacity duration-300"
         onClick={onClose}
       />
 
-      {/* 抽屉内容 */}
-      <div className={`absolute inset-y-0 right-0 w-full ${width} flex`}>
+      <div className={cn('absolute inset-y-0 right-0 flex w-full', width)}>
         <div
-          className="relative w-full flex flex-col
-            bg-card border-l border-white/10
-            shadow-2xl
-            transform transition-transform duration-300 ease-out
-            animate-slide-in-right"
+          className="relative flex w-full animate-slide-in-right flex-col border-l border-white/10 bg-card shadow-2xl"
         >
-          {/* 头部 */}
           <div className="flex items-center justify-between px-6 py-4 border-b border-white/5">
-            {title && (
+            {title ? (
               <div>
                 <span className="label-uppercase">DETAIL VIEW</span>
-                <h2 className="text-lg font-semibold text-white mt-1">
-                  {title}
-                </h2>
+                <h2 className="mt-1 text-lg font-semibold text-white">{title}</h2>
               </div>
-            )}
+            ) : <div />}
             <button
               type="button"
               onClick={onClose}
-              className="dock-item !w-10 !h-10"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-white/10 bg-white/5 text-secondary transition-colors hover:bg-white/10 hover:text-white"
             >
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
               </svg>
             </button>
           </div>
-
-          {/* 内容区 */}
           <div className="flex-1 overflow-y-auto p-6">
             {children}
           </div>

--- a/apps/dsa-web/src/components/common/EmptyState.tsx
+++ b/apps/dsa-web/src/components/common/EmptyState.tsx
@@ -20,7 +20,7 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
     <div className={cn('rounded-2xl border border-dashed border-white/10 bg-card/40 px-6 py-10 text-center shadow-soft-card', className)}>
       {icon ? <div className="mb-4 flex justify-center text-cyan">{icon}</div> : null}
       <h3 className="text-base font-semibold text-white">{title}</h3>
-      {description ? <p className="mx-auto mt-2 max-w-md text-sm text-secondary">{description}</p> : null}
+      {description ? <p className="mx-auto mt-2 max-w-md text-sm text-secondary-text">{description}</p> : null}
       {action ? <div className="mt-5 flex justify-center">{action}</div> : null}
     </div>
   );

--- a/apps/dsa-web/src/components/common/EmptyState.tsx
+++ b/apps/dsa-web/src/components/common/EmptyState.tsx
@@ -1,0 +1,27 @@
+import type React from 'react';
+import { cn } from '../../utils/cn';
+
+interface EmptyStateProps {
+  title: string;
+  description?: string;
+  icon?: React.ReactNode;
+  action?: React.ReactNode;
+  className?: string;
+}
+
+export const EmptyState: React.FC<EmptyStateProps> = ({
+  title,
+  description,
+  icon,
+  action,
+  className = '',
+}) => {
+  return (
+    <div className={cn('rounded-2xl border border-dashed border-white/10 bg-card/40 px-6 py-10 text-center shadow-soft-card', className)}>
+      {icon ? <div className="mb-4 flex justify-center text-cyan">{icon}</div> : null}
+      <h3 className="text-base font-semibold text-white">{title}</h3>
+      {description ? <p className="mx-auto mt-2 max-w-md text-sm text-secondary">{description}</p> : null}
+      {action ? <div className="mt-5 flex justify-center">{action}</div> : null}
+    </div>
+  );
+};

--- a/apps/dsa-web/src/components/common/InlineAlert.tsx
+++ b/apps/dsa-web/src/components/common/InlineAlert.tsx
@@ -1,0 +1,39 @@
+import type React from 'react';
+import { cn } from '../../utils/cn';
+
+type InlineAlertVariant = 'info' | 'success' | 'warning' | 'danger';
+
+interface InlineAlertProps {
+  title?: string;
+  message: React.ReactNode;
+  variant?: InlineAlertVariant;
+  action?: React.ReactNode;
+  className?: string;
+}
+
+const variantStyles: Record<InlineAlertVariant, string> = {
+  info: 'border-cyan/20 bg-cyan/10 text-cyan',
+  success: 'border-success/20 bg-success/10 text-success',
+  warning: 'border-warning/20 bg-warning/10 text-warning',
+  danger: 'border-danger/20 bg-danger/10 text-danger',
+};
+
+export const InlineAlert: React.FC<InlineAlertProps> = ({
+  title,
+  message,
+  variant = 'info',
+  action,
+  className = '',
+}) => {
+  return (
+    <div className={cn('rounded-2xl border px-4 py-3 shadow-soft-card', variantStyles[variant], className)}>
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          {title ? <p className="text-sm font-semibold">{title}</p> : null}
+          <div className={cn('text-sm', title ? 'mt-1 opacity-90' : 'opacity-90')}>{message}</div>
+        </div>
+        {action ? <div className="shrink-0">{action}</div> : null}
+      </div>
+    </div>
+  );
+};

--- a/apps/dsa-web/src/components/common/Input.tsx
+++ b/apps/dsa-web/src/components/common/Input.tsx
@@ -25,7 +25,7 @@ export const Input = ({ label, hint, error, className = '', id, ...props }: Inpu
         aria-invalid={ariaInvalid}
         className={cn(
           'h-11 w-full rounded-xl border border-white/10 bg-card px-4 text-sm text-foreground shadow-soft-card transition-all',
-          'placeholder:text-muted focus:outline-none focus:ring-4 focus:ring-cyan/15 focus:border-cyan/40',
+          'placeholder:text-muted-text focus:outline-none focus:ring-4 focus:ring-cyan/15 focus:border-cyan/40',
           error ? 'border-danger/30 focus:border-danger/40 focus:ring-danger/10' : 'hover:border-white/18',
           className,
         )}
@@ -36,7 +36,7 @@ export const Input = ({ label, hint, error, className = '', id, ...props }: Inpu
           {error}
         </p>
       ) : hint ? (
-        <p id={hintId} className="mt-2 text-xs text-secondary">
+        <p id={hintId} className="mt-2 text-xs text-secondary-text">
           {hint}
         </p>
       ) : null}

--- a/apps/dsa-web/src/components/common/Input.tsx
+++ b/apps/dsa-web/src/components/common/Input.tsx
@@ -1,0 +1,45 @@
+import type React from 'react';
+import { useId } from 'react';
+import { cn } from '../../utils/cn';
+
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  hint?: string;
+  error?: string;
+}
+
+export const Input = ({ label, hint, error, className = '', id, ...props }: InputProps) => {
+  const generatedId = useId();
+  const inputId = id ?? props.name ?? generatedId;
+  const hintId = hint ? `${inputId}-hint` : undefined;
+  const errorId = error ? `${inputId}-error` : undefined;
+  const describedBy = [props['aria-describedby'], errorId ?? hintId].filter(Boolean).join(' ') || undefined;
+  const ariaInvalid = props['aria-invalid'] ?? (error ? true : undefined);
+
+  return (
+    <div className="flex flex-col">
+      {label ? <label htmlFor={inputId} className="mb-2 text-sm font-medium text-foreground">{label}</label> : null}
+      <input
+        id={inputId}
+        aria-describedby={describedBy}
+        aria-invalid={ariaInvalid}
+        className={cn(
+          'h-11 w-full rounded-xl border border-white/10 bg-card px-4 text-sm text-foreground shadow-soft-card transition-all',
+          'placeholder:text-muted focus:outline-none focus:ring-4 focus:ring-cyan/15 focus:border-cyan/40',
+          error ? 'border-danger/30 focus:border-danger/40 focus:ring-danger/10' : 'hover:border-white/18',
+          className,
+        )}
+        {...props}
+      />
+      {error ? (
+        <p id={errorId} role="alert" className="mt-2 text-xs text-danger">
+          {error}
+        </p>
+      ) : hint ? (
+        <p id={hintId} className="mt-2 text-xs text-secondary">
+          {hint}
+        </p>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/dsa-web/src/components/common/Loading.tsx
+++ b/apps/dsa-web/src/components/common/Loading.tsx
@@ -1,9 +1,20 @@
 import React from 'react';
 
-export const Loading: React.FC = () => {
+interface LoadingProps {
+  label?: string;
+  className?: string;
+}
+
+export const Loading: React.FC<LoadingProps> = ({ label = '正在加载', className = '' }) => {
   return (
-    <div className="flex justify-center items-center p-8">
-      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+    <div className={`flex items-center justify-center p-8 ${className}`}>
+      <div className="inline-flex items-center gap-2 rounded-full border border-white/8 bg-card px-4 py-2 text-sm text-secondary shadow-soft-card">
+        <svg className="h-4 w-4 animate-spin text-cyan" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+          <circle className="opacity-20" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+          <path className="opacity-90" fill="currentColor" d="M4 12a8 8 0 0 1 8-8V0C5.373 0 0 5.373 0 12h4z" />
+        </svg>
+        {label}
+      </div>
     </div>
   );
 };

--- a/apps/dsa-web/src/components/common/Loading.tsx
+++ b/apps/dsa-web/src/components/common/Loading.tsx
@@ -8,7 +8,7 @@ interface LoadingProps {
 export const Loading: React.FC<LoadingProps> = ({ label = '正在加载', className = '' }) => {
   return (
     <div className={`flex items-center justify-center p-8 ${className}`}>
-      <div className="inline-flex items-center gap-2 rounded-full border border-white/8 bg-card px-4 py-2 text-sm text-secondary shadow-soft-card">
+      <div className="inline-flex items-center gap-2 rounded-full border border-white/8 bg-card px-4 py-2 text-sm text-secondary-text shadow-soft-card">
         <svg className="h-4 w-4 animate-spin text-cyan" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
           <circle className="opacity-20" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
           <path className="opacity-90" fill="currentColor" d="M4 12a8 8 0 0 1 8-8V0C5.373 0 0 5.373 0 12h4z" />

--- a/apps/dsa-web/src/components/common/PageHeader.tsx
+++ b/apps/dsa-web/src/components/common/PageHeader.tsx
@@ -22,7 +22,7 @@ export const PageHeader: React.FC<PageHeaderProps> = ({
         <div>
           {eyebrow ? <span className="label-uppercase">{eyebrow}</span> : null}
           <h1 className="mt-2 text-2xl font-semibold tracking-tight text-white md:text-3xl">{title}</h1>
-          {description ? <p className="mt-2 max-w-2xl text-sm text-secondary md:text-base">{description}</p> : null}
+          {description ? <p className="mt-2 max-w-2xl text-sm text-secondary-text md:text-base">{description}</p> : null}
         </div>
         {actions ? <div className="flex flex-wrap items-center gap-2">{actions}</div> : null}
       </div>

--- a/apps/dsa-web/src/components/common/PageHeader.tsx
+++ b/apps/dsa-web/src/components/common/PageHeader.tsx
@@ -1,0 +1,31 @@
+import type React from 'react';
+import { cn } from '../../utils/cn';
+
+interface PageHeaderProps {
+  eyebrow?: string;
+  title: string;
+  description?: string;
+  actions?: React.ReactNode;
+  className?: string;
+}
+
+export const PageHeader: React.FC<PageHeaderProps> = ({
+  eyebrow,
+  title,
+  description,
+  actions,
+  className = '',
+}) => {
+  return (
+    <header className={cn('rounded-3xl border border-white/8 bg-card/70 px-5 py-5 shadow-soft-card backdrop-blur-sm', className)}>
+      <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+        <div>
+          {eyebrow ? <span className="label-uppercase">{eyebrow}</span> : null}
+          <h1 className="mt-2 text-2xl font-semibold tracking-tight text-white md:text-3xl">{title}</h1>
+          {description ? <p className="mt-2 max-w-2xl text-sm text-secondary md:text-base">{description}</p> : null}
+        </div>
+        {actions ? <div className="flex flex-wrap items-center gap-2">{actions}</div> : null}
+      </div>
+    </header>
+  );
+};

--- a/apps/dsa-web/src/components/common/Pagination.tsx
+++ b/apps/dsa-web/src/components/common/Pagination.tsx
@@ -13,7 +13,7 @@ const PageButton: React.FC<PageButtonProps> = ({ page, isActive, disabled, onCli
   const isEllipsis = page === '...';
 
   if (isEllipsis) {
-    return <span className="px-3 py-2 text-muted">...</span>;
+    return <span className="px-3 py-2 text-muted-text">...</span>;
   }
 
   return (
@@ -25,7 +25,7 @@ const PageButton: React.FC<PageButtonProps> = ({ page, isActive, disabled, onCli
         'inline-flex h-10 min-w-[2.5rem] items-center justify-center rounded-xl border px-3 text-sm font-medium transition-all duration-200',
         isActive
           ? 'border-cyan/30 bg-cyan text-slate-950 shadow-lg shadow-cyan/20'
-          : 'border-white/8 bg-elevated text-secondary hover:bg-hover hover:text-white',
+          : 'border-white/8 bg-elevated text-secondary-text hover:bg-hover hover:text-white',
         disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
       )}
     >

--- a/apps/dsa-web/src/components/common/Pagination.tsx
+++ b/apps/dsa-web/src/components/common/Pagination.tsx
@@ -1,4 +1,5 @@
 import type React from 'react';
+import { cn } from '../../utils/cn';
 
 interface PageButtonProps {
   page: number | string;
@@ -20,13 +21,13 @@ const PageButton: React.FC<PageButtonProps> = ({ page, isActive, disabled, onCli
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className={`
-        min-w-[40px] h-10 px-3 rounded-lg font-medium
-        transition-all duration-200
-        hover:bg-hover hover:text-white border border-white/5
-        ${isActive ? 'bg-cyan text-muted' : 'bg-elevated text-secondary'}
-        ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}
-      `}
+      className={cn(
+        'inline-flex h-10 min-w-[2.5rem] items-center justify-center rounded-xl border px-3 text-sm font-medium transition-all duration-200',
+        isActive
+          ? 'border-cyan/30 bg-cyan text-slate-950 shadow-lg shadow-cyan/20'
+          : 'border-white/8 bg-elevated text-secondary hover:bg-hover hover:text-white',
+        disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
+      )}
     >
       {children || page}
     </button>
@@ -41,7 +42,7 @@ interface PaginationProps {
 }
 
 /**
- * 分页组件 - 终端风格
+ * Pagination component with terminal-inspired styling.
  */
 export const Pagination: React.FC<PaginationProps> = ({
   currentPage,
@@ -51,7 +52,7 @@ export const Pagination: React.FC<PaginationProps> = ({
 }) => {
   if (totalPages <= 1) return null;
 
-  // 生成页码数组
+  // Build the page list with ellipsis placeholders.
   const getPageNumbers = (): (number | string)[] => {
     const pages: (number | string)[] = [];
     const delta = 2;
@@ -72,8 +73,8 @@ export const Pagination: React.FC<PaginationProps> = ({
   };
 
   return (
-    <div className={`flex items-center justify-center gap-2 ${className}`}>
-      {/* 上一页 */}
+    <div className={cn('flex items-center justify-center gap-2', className)}>
+      {/* Previous page */}
       <PageButton
         page="prev"
         disabled={currentPage === 1}
@@ -84,7 +85,7 @@ export const Pagination: React.FC<PaginationProps> = ({
         </svg>
       </PageButton>
 
-      {/* 页码 */}
+      {/* Page numbers */}
       {getPageNumbers().map((page, index) => (
         <PageButton
           key={`${page}-${index}`}
@@ -94,7 +95,7 @@ export const Pagination: React.FC<PaginationProps> = ({
         />
       ))}
 
-      {/* 下一页 */}
+      {/* Next page */}
       <PageButton
         page="next"
         disabled={currentPage === totalPages}

--- a/apps/dsa-web/src/components/common/ScoreGauge.tsx
+++ b/apps/dsa-web/src/components/common/ScoreGauge.tsx
@@ -89,7 +89,7 @@ export const ScoreGauge: React.FC<ScoreGaugeProps> = ({
   return (
     <div className={cn('flex flex-col items-center', className)}>
       {showLabel && (
-        <span className="label-uppercase mb-3 text-secondary">
+        <span className="label-uppercase mb-3 text-secondary-text">
           恐惧贪婪指数
         </span>
       )}

--- a/apps/dsa-web/src/components/common/ScoreGauge.tsx
+++ b/apps/dsa-web/src/components/common/ScoreGauge.tsx
@@ -1,6 +1,7 @@
 import type React from 'react';
 import { useState, useEffect, useRef } from 'react';
 import { getSentimentLabel } from '../../types/analysis';
+import { cn } from '../../utils/cn';
 
 interface ScoreGaugeProps {
   score: number;
@@ -10,8 +11,7 @@ interface ScoreGaugeProps {
 }
 
 /**
- * 情绪评分仪表盘 - 发光环形进度条
- * 参考金融终端风格设计，带过渡动画
+ * Sentiment score gauge with an animated glowing ring.
  */
 export const ScoreGauge: React.FC<ScoreGaugeProps> = ({
   score,
@@ -19,24 +19,24 @@ export const ScoreGauge: React.FC<ScoreGaugeProps> = ({
   showLabel = true,
   className = '',
 }) => {
-  // 动画状态
+  // Animated score state.
   const [animatedScore, setAnimatedScore] = useState(0);
   const [displayScore, setDisplayScore] = useState(0);
   const animationRef = useRef<number | null>(null);
   const prevScoreRef = useRef(0);
 
-  // 动画效果
+  // Animate transitions between score updates.
   useEffect(() => {
     const startScore = prevScoreRef.current;
     const endScore = score;
-    const duration = 1000; // 动画时长 ms
+    const duration = 1000; // Animation duration in ms.
     const startTime = performance.now();
 
     const animate = (currentTime: number) => {
       const elapsed = currentTime - startTime;
       const progress = Math.min(elapsed / duration, 1);
       
-      // 使用 easeOutCubic 缓动函数
+      // Use an ease-out cubic curve for a smoother finish.
       const easeOut = 1 - Math.pow(1 - progress, 3);
       
       const currentScore = startScore + (endScore - startScore) * easeOut;
@@ -61,7 +61,7 @@ export const ScoreGauge: React.FC<ScoreGaugeProps> = ({
 
   const label = getSentimentLabel(score);
 
-  // 尺寸配置
+  // Size configuration for each gauge variant.
   const sizeConfig = {
     sm: { width: 100, stroke: 8, fontSize: 'text-2xl', labelSize: 'text-xs', gap: 6 },
     md: { width: 140, stroke: 10, fontSize: 'text-4xl', labelSize: 'text-sm', gap: 8 },
@@ -72,23 +72,22 @@ export const ScoreGauge: React.FC<ScoreGaugeProps> = ({
   const radius = (width - stroke) / 2;
   const circumference = 2 * Math.PI * radius;
   
-  // 从顶部开始，显示 270 度（3/4 圆弧）
+  // Start from the top and render a 270-degree arc.
   const arcLength = circumference * 0.75;
   const progress = (animatedScore / 100) * arcLength;
 
-  // 颜色映射 - 使用动画分数计算颜色过渡
+  // Map the animated score to the active gauge color.
   const getStrokeColor = (s: number) => {
-    if (s >= 60) return '#00d4ff'; // 青色 - 贪婪
-    if (s >= 40) return '#a855f7'; // 紫色 - 中性
-    return '#ff4466'; // 红色 - 恐惧
+    if (s >= 60) return '#00d4ff'; // Cyan for greed.
+    if (s >= 40) return '#a855f7'; // Purple for neutral.
+    return '#ff4466'; // Red for fear.
   };
 
   const strokeColor = getStrokeColor(animatedScore);
   const glowColor = `${strokeColor}66`;
 
   return (
-    <div className={`flex flex-col items-center ${className}`}>
-      {/* 标题 */}
+    <div className={cn('flex flex-col items-center', className)}>
       {showLabel && (
         <span className="label-uppercase mb-3 text-secondary">
           恐惧贪婪指数
@@ -103,13 +102,13 @@ export const ScoreGauge: React.FC<ScoreGaugeProps> = ({
           style={{ filter: `drop-shadow(0 0 12px ${glowColor})` }}
         >
           <defs>
-            {/* 渐变定义 */}
+            {/* Gradient definition */}
             <linearGradient id={`gauge-gradient-${score}`} x1="0%" y1="0%" x2="100%" y2="100%">
               <stop offset="0%" stopColor={strokeColor} stopOpacity="0.6" />
               <stop offset="100%" stopColor={strokeColor} stopOpacity="1" />
             </linearGradient>
             
-            {/* 发光滤镜 */}
+            {/* Glow filter */}
             <filter id={`gauge-glow-${score}`}>
               <feGaussianBlur stdDeviation="4" result="blur" />
               <feMerge>
@@ -119,7 +118,7 @@ export const ScoreGauge: React.FC<ScoreGaugeProps> = ({
             </filter>
           </defs>
 
-          {/* 背景轨道 - 3/4 圆弧 */}
+          {/* Background track */}
           <circle
             cx={width / 2}
             cy={width / 2}
@@ -132,7 +131,7 @@ export const ScoreGauge: React.FC<ScoreGaugeProps> = ({
             transform={`rotate(135 ${width / 2} ${width / 2})`}
           />
 
-          {/* 发光层 */}
+          {/* Glow layer */}
           <circle
             cx={width / 2}
             cy={width / 2}
@@ -147,7 +146,7 @@ export const ScoreGauge: React.FC<ScoreGaugeProps> = ({
             filter={`url(#gauge-glow-${score})`}
           />
 
-          {/* 进度圆弧 */}
+          {/* Progress arc */}
           <circle
             cx={width / 2}
             cy={width / 2}
@@ -161,14 +160,9 @@ export const ScoreGauge: React.FC<ScoreGaugeProps> = ({
           />
         </svg>
 
-        {/* 中心数值 */}
+        {/* Center value */}
         <div className="absolute inset-0 flex flex-col items-center justify-center">
-          <span
-            className={`font-bold ${fontSize} text-white`}
-            style={{ 
-              textShadow: `0 0 30px ${glowColor}`,
-            }}
-          >
+          <span className={cn('font-bold text-white', fontSize)} style={{ textShadow: `0 0 30px ${glowColor}` }}>
             {displayScore}
           </span>
           {showLabel && (

--- a/apps/dsa-web/src/components/common/SectionCard.tsx
+++ b/apps/dsa-web/src/components/common/SectionCard.tsx
@@ -1,0 +1,31 @@
+import type React from 'react';
+import { Card } from './Card';
+
+interface SectionCardProps {
+  title: string;
+  subtitle?: string;
+  actions?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const SectionCard: React.FC<SectionCardProps> = ({
+  title,
+  subtitle,
+  actions,
+  children,
+  className = '',
+}) => {
+  return (
+    <Card className={className} padding="md" variant="bordered">
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div>
+          {subtitle ? <span className="label-uppercase">{subtitle}</span> : null}
+          <h2 className="mt-1 text-lg font-semibold text-white">{title}</h2>
+        </div>
+        {actions ? <div className="flex shrink-0 items-center gap-2">{actions}</div> : null}
+      </div>
+      {children}
+    </Card>
+  );
+};

--- a/apps/dsa-web/src/components/common/Select.tsx
+++ b/apps/dsa-web/src/components/common/Select.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useId } from 'react';
+import { cn } from '../../utils/cn';
 
 interface SelectOption {
   value: string;
@@ -13,11 +14,13 @@ interface SelectProps {
   placeholder?: string;
   disabled?: boolean;
   className?: string;
+  searchable?: boolean;
+  searchPlaceholder?: string;
+  emptyText?: string;
 }
 
 /**
- * 下拉选择器组件
- * 科技感样式
+ * Select component with terminal-inspired styling.
  */
 export const Select: React.FC<SelectProps> = ({
   value,
@@ -28,28 +31,23 @@ export const Select: React.FC<SelectProps> = ({
   disabled = false,
   className = '',
 }) => {
+  const selectId = useId();
+
   return (
-    <div className={`flex flex-col ${className}`}>
-      {label && (
-        <label className="mb-2 text-sm font-medium text-gray-300">
-          {label}
-        </label>
-      )}
+    <div className={cn('flex flex-col', className)}>
+      {label ? <label htmlFor={selectId} className="mb-2 text-sm font-medium text-foreground">{label}</label> : null}
       <div className="relative">
         <select
+          id={selectId}
           value={value}
           onChange={(e) => onChange(e.target.value)}
           disabled={disabled}
-          className={`
-            w-full appearance-none px-4 py-2.5 pr-10 rounded-lg
-            bg-slate-800/50 border border-cyan-500/20
-            text-gray-200 placeholder-gray-500
-            focus:outline-none focus:ring-2 focus:ring-cyan-500/40 focus:border-cyan-500/40
-            hover:border-cyan-500/30
-            disabled:opacity-50 disabled:cursor-not-allowed
-            transition-all duration-200
-            cursor-pointer
-          `}
+          className={cn(
+            'h-11 w-full appearance-none rounded-xl border border-white/10 bg-card px-4 py-2.5 pr-10 text-sm text-foreground',
+            'shadow-soft-card transition-all duration-200 focus:outline-none focus:ring-4 focus:ring-cyan/15 focus:border-cyan/40',
+            'hover:border-white/18',
+            disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
+          )}
         >
           {placeholder && (
             <option value="" disabled>
@@ -63,10 +61,10 @@ export const Select: React.FC<SelectProps> = ({
           ))}
         </select>
 
-        {/* 下拉箭头 */}
+        {/* Dropdown arrow */}
         <div className="absolute inset-y-0 right-0 flex items-center pr-3 pointer-events-none">
           <svg
-            className="w-4 h-4 text-cyan-400"
+            className="h-4 w-4 text-secondary"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"

--- a/apps/dsa-web/src/components/common/Select.tsx
+++ b/apps/dsa-web/src/components/common/Select.tsx
@@ -55,7 +55,7 @@ export const Select: React.FC<SelectProps> = ({
             </option>
           )}
           {options.map((option) => (
-            <option key={option.value} value={option.value} className="bg-slate-800">
+            <option key={option.value} value={option.value} className="bg-elevated text-foreground">
               {option.label}
             </option>
           ))}
@@ -64,7 +64,7 @@ export const Select: React.FC<SelectProps> = ({
         {/* Dropdown arrow */}
         <div className="absolute inset-y-0 right-0 flex items-center pr-3 pointer-events-none">
           <svg
-            className="h-4 w-4 text-secondary"
+            className="h-4 w-4 text-secondary-text"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"

--- a/apps/dsa-web/src/components/common/StatCard.tsx
+++ b/apps/dsa-web/src/components/common/StatCard.tsx
@@ -36,9 +36,9 @@ export const StatCard: React.FC<StatCardProps> = ({
     <div className={cn('rounded-2xl border bg-card/75 p-4 shadow-soft-card', toneStyles[tone], className)}>
       <div className="flex items-start justify-between gap-3">
         <div>
-          <p className="text-xs uppercase tracking-[0.22em] text-secondary">{label}</p>
+          <p className="text-xs uppercase tracking-[0.22em] text-secondary-text">{label}</p>
           <div className="mt-2 text-2xl font-semibold text-white">{value}</div>
-          {hint ? <div className="mt-2 text-sm text-secondary">{hint}</div> : null}
+          {hint ? <div className="mt-2 text-sm text-secondary-text">{hint}</div> : null}
         </div>
         {icon ? <div className="text-cyan">{icon}</div> : null}
       </div>

--- a/apps/dsa-web/src/components/common/StatCard.tsx
+++ b/apps/dsa-web/src/components/common/StatCard.tsx
@@ -1,0 +1,47 @@
+import type React from 'react';
+import { cn } from '../../utils/cn';
+
+interface StatCardProps {
+  /** Metric label, such as "Total Return". */
+  label: string;
+  /** Metric value, including numbers or percentages. */
+  value: React.ReactNode;
+  /** Supporting text, such as "Up 5% vs last month". */
+  hint?: React.ReactNode;
+  /** Optional trailing icon. */
+  icon?: React.ReactNode;
+  /** Tone variant that affects the border color. */
+  tone?: 'default' | 'primary' | 'success' | 'warning' | 'danger';
+  /** Optional extra className. */
+  className?: string;
+}
+
+const toneStyles = {
+  default: 'border-white/8',
+  primary: 'border-cyan/18',
+  success: 'border-success/18',
+  warning: 'border-warning/18',
+  danger: 'border-danger/18',
+};
+
+export const StatCard: React.FC<StatCardProps> = ({
+  label,
+  value,
+  hint,
+  icon,
+  tone = 'default',
+  className = '',
+}) => {
+  return (
+    <div className={cn('rounded-2xl border bg-card/75 p-4 shadow-soft-card', toneStyles[tone], className)}>
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs uppercase tracking-[0.22em] text-secondary">{label}</p>
+          <div className="mt-2 text-2xl font-semibold text-white">{value}</div>
+          {hint ? <div className="mt-2 text-sm text-secondary">{hint}</div> : null}
+        </div>
+        {icon ? <div className="text-cyan">{icon}</div> : null}
+      </div>
+    </div>
+  );
+};

--- a/apps/dsa-web/src/components/common/StickyActionBar.tsx
+++ b/apps/dsa-web/src/components/common/StickyActionBar.tsx
@@ -1,0 +1,15 @@
+import type React from 'react';
+import { cn } from '../../utils/cn';
+
+interface StickyActionBarProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const StickyActionBar: React.FC<StickyActionBarProps> = ({ children, className = '' }) => {
+  return (
+    <div className={cn('sticky bottom-4 z-20 rounded-2xl border border-white/8 bg-card/85 p-3 shadow-soft-card backdrop-blur-md', className)}>
+      <div className="flex flex-wrap items-center justify-end gap-2">{children}</div>
+    </div>
+  );
+};

--- a/apps/dsa-web/src/components/common/ToastViewport.tsx
+++ b/apps/dsa-web/src/components/common/ToastViewport.tsx
@@ -1,0 +1,15 @@
+import type React from 'react';
+import { cn } from '../../utils/cn';
+
+interface ToastViewportProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const ToastViewport: React.FC<ToastViewportProps> = ({ children, className = '' }) => {
+  return (
+    <div className={cn('pointer-events-none fixed bottom-5 right-5 z-50 flex w-[360px] max-w-[calc(100vw-24px)] flex-col gap-3', className)}>
+      {children}
+    </div>
+  );
+};

--- a/apps/dsa-web/src/components/common/Toolbar.tsx
+++ b/apps/dsa-web/src/components/common/Toolbar.tsx
@@ -1,0 +1,17 @@
+import type React from 'react';
+import { cn } from '../../utils/cn';
+
+interface ToolbarProps {
+  left?: React.ReactNode;
+  right?: React.ReactNode;
+  className?: string;
+}
+
+export const Toolbar: React.FC<ToolbarProps> = ({ left, right, className = '' }) => {
+  return (
+    <div className={cn('flex flex-col gap-3 rounded-2xl border border-white/8 bg-card/60 px-4 py-3 shadow-soft-card backdrop-blur-sm md:flex-row md:items-center md:justify-between', className)}>
+      <div className="flex flex-wrap items-center gap-2">{left}</div>
+      <div className="flex flex-wrap items-center gap-2 md:justify-end">{right}</div>
+    </div>
+  );
+};

--- a/apps/dsa-web/src/components/common/index.ts
+++ b/apps/dsa-web/src/components/common/index.ts
@@ -1,5 +1,15 @@
 export * from './Button';
 export * from './Card';
+export * from './AppPage';
+export * from './SectionCard';
+export * from './StatCard';
+export * from './EmptyState';
+export * from './InlineAlert';
+export * from './StickyActionBar';
+export * from './Toolbar';
+export * from './ToastViewport';
+export * from './PageHeader';
+export { Input } from './Input';
 export * from './EyeToggleIcon';
 export * from './Loading';
 export * from './Drawer';

--- a/apps/dsa-web/src/components/history/HistoryList.tsx
+++ b/apps/dsa-web/src/components/history/HistoryList.tsx
@@ -10,20 +10,14 @@ interface HistoryListProps {
   isLoadingMore: boolean;
   hasMore: boolean;
   selectedId?: number;  // Selected history record ID
-  selectedIds: Set<number>;
-  isDeleting?: boolean;
   onItemClick: (recordId: number) => void;  // Callback with record ID
   onLoadMore: () => void;
-  onToggleItemSelection: (recordId: number) => void;
-  onToggleSelectAll: () => void;
-  onDeleteSelected: () => void;
   className?: string;
 }
 
 /**
- * History record list component.
- * Displays recent stock analysis history, supports clicking for details, scroll-to-load-more, 
- * and batch selection for deletion.
+ * 历史记录列表组件
+ * 显示最近的股票分析历史，支持点击查看详情和滚动加载更多
  */
 export const HistoryList: React.FC<HistoryListProps> = ({
   items,
@@ -31,30 +25,20 @@ export const HistoryList: React.FC<HistoryListProps> = ({
   isLoadingMore,
   hasMore,
   selectedId,
-  selectedIds,
-  isDeleting = false,
   onItemClick,
   onLoadMore,
-  onToggleItemSelection,
-  onToggleSelectAll,
-  onDeleteSelected,
   className = '',
 }) => {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const loadMoreTriggerRef = useRef<HTMLDivElement>(null);
-  const selectAllRef = useRef<HTMLInputElement>(null);
 
-  const selectedCount = items.filter((item) => selectedIds.has(item.id)).length;
-  const allVisibleSelected = items.length > 0 && selectedCount === items.length;
-  const someVisibleSelected = selectedCount > 0 && !allVisibleSelected;
-
-  // Use IntersectionObserver to detect scrolling to bottom
+  // 使用 IntersectionObserver 检测滚动到底部
   const handleObserver = useCallback(
     (entries: IntersectionObserverEntry[]) => {
       const target = entries[0];
-      // Only load when trigger is truly visible and more data exists
+      // 只有当触发器真正可见且有更多数据时才加载
       if (target.isIntersecting && hasMore && !isLoading && !isLoadingMore) {
-        // Ensure container has scroll capacity (content exceeds container height)
+        // 确保容器有滚动能力（内容超过容器高度）
         const container = scrollContainerRef.current;
         if (container && container.scrollHeight > container.clientHeight) {
           onLoadMore();
@@ -71,8 +55,8 @@ export const HistoryList: React.FC<HistoryListProps> = ({
 
     const observer = new IntersectionObserver(handleObserver, {
       root: container,
-      rootMargin: '20px', // Reduce pre-load distance
-      threshold: 0.1, // Trigger only when at least 10% of trigger is visible
+      rootMargin: '20px', // 减小预加载距离
+      threshold: 0.1, // 触发器至少 10% 可见时才触发
     });
 
     observer.observe(trigger);
@@ -82,125 +66,75 @@ export const HistoryList: React.FC<HistoryListProps> = ({
     };
   }, [handleObserver]);
 
-  useEffect(() => {
-    if (selectAllRef.current) {
-      selectAllRef.current.indeterminate = someVisibleSelected;
-    }
-  }, [someVisibleSelected]);
-
   return (
     <aside className={`glass-card overflow-hidden flex flex-col ${className}`}>
       <div ref={scrollContainerRef} className="p-3 flex-1 overflow-y-auto">
-        <div className="mb-3 space-y-2">
-          <div className="flex items-center justify-between gap-2">
-            <h2 className="text-xs font-medium text-purple uppercase tracking-wider flex items-center gap-1.5">
-              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-              历史记录
-            </h2>
-            {selectedCount > 0 && (
-              <span className="text-xs text-muted">
-                已选 {selectedCount} 项
-              </span>
-            )}
-          </div>
-
-          {items.length > 0 && (
-            <div className="flex flex-wrap items-center gap-2 text-xs">
-              <label className="inline-flex items-center gap-2 text-muted cursor-pointer">
-                <input
-                  ref={selectAllRef}
-                  type="checkbox"
-                  checked={allVisibleSelected}
-                  disabled={isDeleting}
-                  onChange={onToggleSelectAll}
-                />
-                <span>全选当前已加载</span>
-              </label>
-              <button
-                type="button"
-                className="btn-secondary !px-3 !py-1.5 !text-xs"
-                onClick={onDeleteSelected}
-                disabled={selectedCount === 0 || isDeleting}
-              >
-                {isDeleting ? '删除中...' : '删除已选'}
-              </button>
-            </div>
-          )}
-        </div>
+        <h2 className="text-xs font-medium text-purple uppercase tracking-wider mb-3 flex items-center gap-1.5">
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          历史记录
+        </h2>
 
         {isLoading ? (
           <div className="flex justify-center py-6">
             <div className="w-5 h-5 border-2 border-cyan/20 border-t-cyan rounded-full animate-spin" />
           </div>
         ) : items.length === 0 ? (
-          <div className="text-center py-6 text-muted text-xs">
+          <div className="text-center py-6 text-muted-text text-xs">
             暂无历史记录
           </div>
         ) : (
           <div className="space-y-1.5">
-            {items.map((item) => {
-              const checked = selectedIds.has(item.id);
-              return (
-                <div key={item.id} className="flex items-start gap-2">
-                  <label className="pt-3 cursor-pointer">
-                    <input
-                      type="checkbox"
-                      checked={checked}
-                      disabled={isDeleting}
-                      onChange={() => onToggleItemSelection(item.id)}
-                      aria-label={`选择历史记录 ${item.stockName || item.stockCode}`}
+            {items.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                onClick={() => onItemClick(item.id)}
+                className={`history-item w-full text-left ${selectedId === item.id ? 'active' : ''
+                  }`}
+              >
+                <div className="flex items-center gap-2 w-full">
+                  {/* 情感分数指示条 */}
+                  {item.sentimentScore !== undefined && (
+                    <span
+                      className="w-0.5 h-8 rounded-full flex-shrink-0"
+                      style={{
+                        backgroundColor: getSentimentColor(item.sentimentScore),
+                        boxShadow: `0 0 6px ${getSentimentColor(item.sentimentScore)}40`
+                      }}
                     />
-                  </label>
-                  <button
-                    type="button"
-                    onClick={() => onItemClick(item.id)}
-                    className={`history-item w-full text-left ${selectedId === item.id ? 'active' : ''}`}
-                  >
-                    <div className="flex items-center gap-2 w-full">
-                      {/* Sentiment score indicator bar */}
+                  )}
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center justify-between gap-1.5">
+                      <span className="font-medium text-white truncate text-xs">
+                        {item.stockName || item.stockCode}
+                      </span>
                       {item.sentimentScore !== undefined && (
                         <span
-                          className="w-0.5 h-8 rounded-full flex-shrink-0"
+                          className="text-xs font-mono font-semibold px-1 py-0.5 rounded"
                           style={{
-                            backgroundColor: getSentimentColor(item.sentimentScore),
-                            boxShadow: `0 0 6px ${getSentimentColor(item.sentimentScore)}40`
+                            color: getSentimentColor(item.sentimentScore),
+                            backgroundColor: `${getSentimentColor(item.sentimentScore)}15`
                           }}
-                        />
+                        >
+                          {item.sentimentScore}
+                        </span>
                       )}
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center justify-between gap-1.5">
-                          <span className="font-medium text-white truncate text-xs">
-                            {item.stockName || item.stockCode}
-                          </span>
-                          {item.sentimentScore !== undefined && (
-                            <span
-                              className="text-xs font-mono font-semibold px-1 py-0.5 rounded"
-                              style={{
-                                color: getSentimentColor(item.sentimentScore),
-                                backgroundColor: `${getSentimentColor(item.sentimentScore)}15`
-                              }}
-                            >
-                              {item.sentimentScore}
-                            </span>
-                          )}
-                        </div>
-                        <div className="flex items-center gap-1.5 mt-0.5">
-                          <span className="text-xs text-muted font-mono">
-                            {item.stockCode}
-                          </span>
-                          <span className="text-xs text-muted/50">·</span>
-                          <span className="text-xs text-muted">
-                            {formatDateTime(item.createdAt)}
-                          </span>
-                        </div>
-                      </div>
                     </div>
-                  </button>
+                    <div className="flex items-center gap-1.5 mt-0.5">
+                      <span className="text-xs text-muted-text font-mono">
+                        {item.stockCode}
+                      </span>
+                      <span className="text-xs text-muted-text/50">·</span>
+                      <span className="text-xs text-muted-text">
+                        {formatDateTime(item.createdAt)}
+                      </span>
+                    </div>
+                  </div>
                 </div>
-              );
-            })}
+              </button>
+            ))}
 
             {/* 加载更多触发器 */}
             <div ref={loadMoreTriggerRef} className="h-4" />
@@ -214,7 +148,7 @@ export const HistoryList: React.FC<HistoryListProps> = ({
 
             {/* 没有更多数据提示 */}
             {!hasMore && items.length > 0 && (
-              <div className="text-center py-2 text-muted/50 text-xs">
+              <div className="text-center py-2 text-muted-text/50 text-xs">
                 已加载全部
               </div>
             )}

--- a/apps/dsa-web/src/components/report/ReportDetails.tsx
+++ b/apps/dsa-web/src/components/report/ReportDetails.tsx
@@ -40,11 +40,11 @@ export const ReportDetails: React.FC<ReportDetailsProps> = ({
         <button
           type="button"
           onClick={() => copyToClipboard(jsonStr)}
-          className="absolute top-2 right-2 text-xs text-muted hover:text-cyan transition-colors"
+          className="absolute top-2 right-2 text-xs text-muted-text hover:text-cyan transition-colors"
         >
           {copied ? 'Copied!' : 'Copy'}
         </button>
-        <pre className="text-xs text-secondary font-mono overflow-x-auto p-3 bg-base rounded-lg max-h-80 overflow-y-auto text-left w-0 min-w-full">
+        <pre className="text-xs text-secondary-text font-mono overflow-x-auto p-3 bg-base rounded-lg max-h-80 overflow-y-auto text-left w-0 min-w-full">
           {jsonStr}
         </pre>
       </div>
@@ -60,7 +60,7 @@ export const ReportDetails: React.FC<ReportDetailsProps> = ({
 
       {/* Record ID */}
       {recordId && (
-        <div className="flex items-center gap-2 text-xs text-muted mb-3 pb-3 border-b border-white/5">
+        <div className="flex items-center gap-2 text-xs text-muted-text mb-3 pb-3 border-b border-white/5">
           <span>Record ID:</span>
           <code className="font-mono text-xs text-cyan bg-cyan/10 px-1.5 py-0.5 rounded">
             {recordId}
@@ -80,7 +80,7 @@ export const ReportDetails: React.FC<ReportDetailsProps> = ({
             >
               <span className="text-xs text-white">原始分析结果</span>
               <svg
-                className={`w-3.5 h-3.5 text-muted transition-transform ${showRaw ? 'rotate-180' : ''}`}
+                className={`w-3.5 h-3.5 text-muted-text transition-transform ${showRaw ? 'rotate-180' : ''}`}
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -106,7 +106,7 @@ export const ReportDetails: React.FC<ReportDetailsProps> = ({
             >
               <span className="text-xs text-white">分析快照</span>
               <svg
-                className={`w-3.5 h-3.5 text-muted transition-transform ${showSnapshot ? 'rotate-180' : ''}`}
+                className={`w-3.5 h-3.5 text-muted-text transition-transform ${showSnapshot ? 'rotate-180' : ''}`}
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"

--- a/apps/dsa-web/src/components/report/ReportMarkdown.tsx
+++ b/apps/dsa-web/src/components/report/ReportMarkdown.tsx
@@ -74,7 +74,7 @@ export const ReportMarkdown: React.FC<ReportMarkdownProps> = ({
         </div>
         <div>
           <h2 className="text-base font-semibold text-white">{stockName || stockCode}</h2>
-          <p className="text-xs text-muted">完整分析报告</p>
+          <p className="text-xs text-muted-text">完整分析报告</p>
         </div>
       </div>
 
@@ -82,7 +82,7 @@ export const ReportMarkdown: React.FC<ReportMarkdownProps> = ({
       {isLoading ? (
         <div className="flex flex-col items-center justify-center h-64">
           <div className="w-10 h-10 border-3 border-purple/20 border-t-purple rounded-full animate-spin" />
-          <p className="mt-4 text-secondary text-sm">加载报告中...</p>
+          <p className="mt-4 text-secondary-text text-sm">加载报告中...</p>
         </div>
       ) : error ? (
         <div className="flex flex-col items-center justify-center h-64">
@@ -95,7 +95,7 @@ export const ReportMarkdown: React.FC<ReportMarkdownProps> = ({
           <button
             type="button"
             onClick={handleClose}
-            className="mt-4 px-4 py-2 rounded-lg bg-white/5 hover:bg-white/10 text-sm text-secondary transition-colors"
+            className="mt-4 px-4 py-2 rounded-lg bg-white/5 hover:bg-white/10 text-sm text-secondary-text transition-colors"
           >
             关闭
           </button>
@@ -118,7 +118,7 @@ export const ReportMarkdown: React.FC<ReportMarkdownProps> = ({
             prose-hr:border-white/10 prose-hr:my-4
             prose-a:text-cyan prose-a:no-underline hover:prose-a:underline
             prose-blockquote:border-purple/30 prose-blockquote:bg-purple/5 prose-blockquote:py-2 prose-blockquote:px-4 prose-blockquote:rounded-r-lg
-            prose-blockquote:text-secondary
+            prose-blockquote:text-secondary-text
             whitespace-pre-line break-words
           "
         >
@@ -133,7 +133,7 @@ export const ReportMarkdown: React.FC<ReportMarkdownProps> = ({
         <button
           type="button"
           onClick={handleClose}
-          className="px-4 py-2 rounded-lg bg-white/5 hover:bg-white/10 text-sm text-secondary hover:text-white transition-colors"
+          className="px-4 py-2 rounded-lg bg-white/5 hover:bg-white/10 text-sm text-secondary-text hover:text-white transition-colors"
         >
           关闭
         </button>

--- a/apps/dsa-web/src/components/report/ReportNews.tsx
+++ b/apps/dsa-web/src/components/report/ReportNews.tsx
@@ -78,14 +78,14 @@ export const ReportNews: React.FC<ReportNewsProps> = ({ recordId, limit = 20 }) 
       )}
 
       {isLoading && !error && (
-        <div className="flex items-center gap-2 text-xs text-secondary">
+        <div className="flex items-center gap-2 text-xs text-secondary-text">
           <div className="w-4 h-4 border-2 border-cyan/20 border-t-cyan rounded-full animate-spin" />
           加载资讯中...
         </div>
       )}
 
       {!isLoading && !error && items.length === 0 && (
-        <div className="text-xs text-muted">暂无相关资讯</div>
+        <div className="text-xs text-muted-text">暂无相关资讯</div>
       )}
 
       {!isLoading && !error && items.length > 0 && (
@@ -101,7 +101,7 @@ export const ReportNews: React.FC<ReportNewsProps> = ({ recordId, limit = 20 }) 
                     {item.title}
                   </p>
                   {item.snippet && (
-                    <p className="text-xs text-secondary mt-1 text-left">
+                    <p className="text-xs text-secondary-text mt-1 text-left">
                       {item.snippet}
                     </p>
                   )}

--- a/apps/dsa-web/src/components/report/ReportOverview.tsx
+++ b/apps/dsa-web/src/components/report/ReportOverview.tsx
@@ -18,10 +18,10 @@ export const ReportOverview: React.FC<ReportOverviewProps> = ({
 }) => {
   // 根据涨跌幅获取颜色
   const getPriceChangeColor = (changePct: number | undefined): string => {
-    if (changePct === undefined || changePct === null) return 'text-muted';
+    if (changePct === undefined || changePct === null) return 'text-muted-text';
     if (changePct > 0) return 'text-[#ff4d4d]'; // 红涨
     if (changePct < 0) return 'text-[#00d46a]'; // 绿跌
-    return 'text-muted';
+    return 'text-muted-text';
   };
 
   // 格式化涨跌幅
@@ -61,7 +61,7 @@ export const ReportOverview: React.FC<ReportOverviewProps> = ({
                   <span className="font-mono text-xs text-cyan bg-cyan/10 px-1.5 py-0.5 rounded">
                     {meta.stockCode}
                   </span>
-                  <span className="text-xs text-muted flex items-center gap-1">
+                  <span className="text-xs text-muted-text flex items-center gap-1">
                     <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
                     </svg>

--- a/apps/dsa-web/src/components/report/ReportStrategy.tsx
+++ b/apps/dsa-web/src/components/report/ReportStrategy.tsx
@@ -19,10 +19,10 @@ const StrategyItem: React.FC<StrategyItemProps> = ({
 }) => (
   <div className="relative overflow-hidden rounded-lg bg-elevated border border-white/5 p-3 hover:border-white/10 transition-colors">
     <div className="flex flex-col">
-      <span className="text-xs text-muted mb-0.5">{label}</span>
+      <span className="text-xs text-muted-text mb-0.5">{label}</span>
       <span
         className="text-lg font-bold font-mono"
-        style={{ color: value ? color : 'var(--text-muted)' }}
+        style={{ color: value ? color : 'var(--text-muted-text)' }}
       >
         {value || '—'}
       </span>

--- a/apps/dsa-web/src/components/settings/ChangePasswordCard.tsx
+++ b/apps/dsa-web/src/components/settings/ChangePasswordCard.tsx
@@ -65,13 +65,13 @@ export const ChangePasswordCard: React.FC = () => {
       <div className="mb-2 flex items-center gap-2">
         <label className="text-sm font-semibold text-white">修改密码</label>
       </div>
-      <p className="mb-3 text-xs text-muted">修改管理员登录密码</p>
+      <p className="mb-3 text-xs text-muted-text">修改管理员登录密码</p>
 
       <form onSubmit={handleSubmit} className="space-y-3">
         <div>
           <label
             htmlFor="change-pass-current"
-            className="mb-1 block text-xs font-medium text-secondary"
+            className="mb-1 block text-xs font-medium text-secondary-text"
           >
             当前密码
           </label>
@@ -101,7 +101,7 @@ export const ChangePasswordCard: React.FC = () => {
         <div>
           <label
             htmlFor="change-pass-new"
-            className="mb-1 block text-xs font-medium text-secondary"
+            className="mb-1 block text-xs font-medium text-secondary-text"
           >
             新密码
           </label>
@@ -131,7 +131,7 @@ export const ChangePasswordCard: React.FC = () => {
         <div>
           <label
             htmlFor="change-pass-confirm"
-            className="mb-1 block text-xs font-medium text-secondary"
+            className="mb-1 block text-xs font-medium text-secondary-text"
           >
             确认新密码
           </label>

--- a/apps/dsa-web/src/components/settings/IntelligentImport.tsx
+++ b/apps/dsa-web/src/components/settings/IntelligentImport.tsx
@@ -272,7 +272,7 @@ export const IntelligentImport: React.FC<IntelligentImportProps> = ({
   return (
     <div className="rounded-xl border border-white/8 bg-elevated/40 p-4">
       <p className="mb-2 text-sm font-medium text-white">智能导入</p>
-      <p className="mb-3 text-xs text-muted">
+      <p className="mb-3 text-xs text-muted-text">
         支持图片、CSV/Excel 文件、剪贴板粘贴。图片需配置 Vision API。建议人工核对后再合并。
       </p>
 
@@ -297,7 +297,7 @@ export const IntelligentImport: React.FC<IntelligentImportProps> = ({
         <div className="flex gap-2">
           <textarea
             placeholder="或粘贴 CSV/Excel 复制的文本..."
-            className="min-h-[60px] w-full rounded-lg border border-white/16 bg-card/60 px-2 py-1.5 text-sm text-white placeholder:text-muted"
+            className="min-h-[60px] w-full rounded-lg border border-white/16 bg-card/60 px-2 py-1.5 text-sm text-white placeholder:text-muted-text"
             value={pasteText}
             onChange={(e) => setPasteText(e.target.value)}
             disabled={disabled || isLoading}
@@ -308,7 +308,7 @@ export const IntelligentImport: React.FC<IntelligentImportProps> = ({
         </div>
       </div>
 
-      {isLoading && <p className="mb-2 text-sm text-secondary">处理中...</p>}
+      {isLoading && <p className="mb-2 text-sm text-secondary-text">处理中...</p>}
       {error && (
         <div className="mb-3 rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-400">{error}</div>
       )}
@@ -319,17 +319,17 @@ export const IntelligentImport: React.FC<IntelligentImportProps> = ({
             ⚠️ 建议人工逐条核对后再合并。高置信度默认勾选，中/低需手动勾选。
           </p>
           <div className="flex items-center justify-between">
-            <span className="text-xs text-secondary">
+            <span className="text-xs text-secondary-text">
               共 {validCount} 条可合并，已勾选 {checkedCount} 条
             </span>
             <div className="flex gap-2">
-              <button type="button" className="text-xs text-muted hover:text-white" onClick={() => toggleAll(true)}>
+              <button type="button" className="text-xs text-muted-text hover:text-white" onClick={() => toggleAll(true)}>
                 全选
               </button>
-              <button type="button" className="text-xs text-muted hover:text-white" onClick={() => toggleAll(false)}>
+              <button type="button" className="text-xs text-muted-text hover:text-white" onClick={() => toggleAll(false)}>
                 取消
               </button>
-              <button type="button" className="text-xs text-muted hover:text-white" onClick={clearAll}>
+              <button type="button" className="text-xs text-muted-text hover:text-white" onClick={clearAll}>
                 清空
               </button>
             </div>
@@ -352,13 +352,13 @@ export const IntelligentImport: React.FC<IntelligentImportProps> = ({
                 <span className={it.code ? 'text-white' : 'text-red-400'}>
                   {it.code || '解析失败'}
                 </span>
-                {it.name && <span className="text-muted">({it.name})</span>}
-                <span className="ml-auto text-xs text-muted">
+                {it.name && <span className="text-muted-text">({it.name})</span>}
+                <span className="ml-auto text-xs text-muted-text">
                   {it.confidence === 'high' ? '高' : it.confidence === 'low' ? '低' : '中'}
                 </span>
                 <button
                   type="button"
-                  className="text-muted hover:text-white"
+                  className="text-muted-text hover:text-white"
                   onClick={() => removeItem(it.id)}
                   disabled={disabled}
                 >

--- a/apps/dsa-web/src/components/settings/LLMChannelEditor.tsx
+++ b/apps/dsa-web/src/components/settings/LLMChannelEditor.tsx
@@ -3,7 +3,7 @@ import type React from 'react';
 import type { ParsedApiError } from '../../api/error';
 import { getParsedApiError } from '../../api/error';
 import { systemConfigApi } from '../../api/systemConfig';
-import { ApiErrorAlert, EyeToggleIcon, Select } from '../common';
+import { ApiErrorAlert, EyeToggleIcon, Select, Button, Input, Badge } from '../common';
 
 type ChannelProtocol = 'openai' | 'deepseek' | 'gemini' | 'anthropic' | 'vertex_ai' | 'ollama';
 
@@ -198,74 +198,76 @@ const ChannelRow: React.FC<ChannelRowProps> = ({
   const hasKey = channel.apiKey.length > 0;
 
   return (
-    <div className="rounded-lg border border-white/8 bg-card/40 overflow-hidden">
+    <div className="rounded-xl border border-white/8 bg-card/40 overflow-hidden shadow-soft-card mb-2">
       {/* Summary row — always visible */}
       <div
-        className="flex items-center gap-2 px-3 py-2 cursor-pointer select-none hover:bg-white/[0.03] transition-colors"
+        className="flex items-center gap-2 px-4 py-3 cursor-pointer select-none hover:bg-white/[0.04] transition-colors"
         onClick={() => onToggleExpand(index)}
         onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onToggleExpand(index); } }}
         role="button"
         tabIndex={0}
       >
-        <span className="text-[11px] text-muted w-4 shrink-0">{expanded ? '▼' : '▶'}</span>
+        <span className="text-[11px] text-muted-text w-4 shrink-0 transition-transform duration-200" style={{ transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)' }}>▶</span>
 
         <input
           type="checkbox"
           checked={channel.enabled}
           disabled={busy}
-          className="shrink-0"
+          className="shrink-0 w-4 h-4 rounded border-white/10 bg-card text-cyan focus:ring-cyan/20 cursor-pointer"
           onClick={(e) => e.stopPropagation()}
           onChange={(e) => onUpdate(index, 'enabled', e.target.checked)}
         />
 
-        <span className="min-w-[100px] truncate text-sm text-white font-medium">{displayName}</span>
+        <span className="min-w-[120px] truncate text-sm text-white font-semibold">{displayName}</span>
 
-        <span className="hidden sm:inline rounded bg-white/8 px-1.5 py-0.5 text-[10px] text-muted uppercase tracking-wide">
+        <Badge variant="info" size="sm" className="hidden sm:inline-flex opacity-80">
           {channel.protocol}
-        </span>
+        </Badge>
 
-        <span className="text-[11px] text-muted truncate flex-1">
+        <span className="text-xs text-secondary-text truncate flex-1 ml-2">
           {modelCount > 0 ? `${modelCount} 个模型` : '未配置模型'}
         </span>
 
         {/* Status indicators */}
         <span className="flex items-center gap-1.5 shrink-0">
-          {testState?.status === 'success' && <span className="h-2 w-2 rounded-full bg-emerald-400" title="连接正常" />}
-          {testState?.status === 'error' && <span className="h-2 w-2 rounded-full bg-rose-400" title="连接失败" />}
-          {testState?.status === 'loading' && <span className="h-2 w-2 rounded-full bg-amber-400 animate-pulse" title="测试中" />}
+          {testState?.status === 'success' && <span className="h-2 w-2 rounded-full bg-emerald-400 shadow-[0_0_8px_rgba(52,211,153,0.5)]" title="连接正常" />}
+          {testState?.status === 'error' && <span className="h-2 w-2 rounded-full bg-rose-400 shadow-[0_0_8px_rgba(251,113,133,0.5)]" title="连接失败" />}
+          {testState?.status === 'loading' && <span className="h-2 w-2 rounded-full bg-amber-400 animate-pulse shadow-[0_0_8px_rgba(251,191,36,0.5)]" title="测试中" />}
           {!hasKey && channel.protocol !== 'ollama' && (
-            <span className="text-[10px] text-amber-400/80">未填 Key</span>
+            <span className="text-[10px] text-amber-400/80 font-medium">未填 Key</span>
           )}
         </span>
 
         <button
           type="button"
-          className="shrink-0 text-xs text-muted hover:text-rose-300 transition-colors px-1"
+          className="shrink-0 text-muted-text hover:text-danger transition-colors p-1"
           disabled={busy}
           onClick={(e) => { e.stopPropagation(); onRemove(index); }}
           title="删除渠道"
         >
-          ✕
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
         </button>
       </div>
 
       {/* Detail panel — only when expanded */}
       {expanded && (
-        <div className="border-t border-white/6 bg-card/20 px-3 py-3 space-y-2.5">
-          <div className="grid gap-2 sm:grid-cols-2">
-            <div>
-              <label className="mb-0.5 block text-[11px] text-muted">渠道名称</label>
-              <input
-                className="input-terminal text-sm"
-                value={channel.name}
-                disabled={busy}
-                onChange={(e) => onUpdate(index, 'name', e.target.value.toLowerCase().replace(/[^a-z0-9_]/g, ''))}
-                placeholder="primary"
-              />
-            </div>
-            <div>
-              <label className="mb-0.5 block text-[11px] text-muted">协议</label>
+        <div className="border-t border-white/6 bg-white/[0.02] px-4 py-4 space-y-4 animate-in fade-in slide-in-from-top-1 duration-200">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Input
+              label="渠道名称"
+              className="h-10"
+              value={channel.name}
+              disabled={busy}
+              onChange={(e) => onUpdate(index, 'name', e.target.value.toLowerCase().replace(/[^a-z0-9_]/g, ''))}
+              placeholder="primary"
+              hint="只能包含小写字母、数字和下划线"
+            />
+            <div className="flex flex-col">
+              <label className="mb-2 text-sm font-medium text-foreground">协议</label>
               <Select
+                className="h-10"
                 value={channel.protocol}
                 onChange={(v) => onUpdate(index, 'protocol', normalizeProtocol(v))}
                 options={PROTOCOL_OPTIONS}
@@ -275,70 +277,67 @@ const ChannelRow: React.FC<ChannelRowProps> = ({
             </div>
           </div>
 
-          <div>
-            <label className="mb-0.5 block text-[11px] text-muted">Base URL</label>
-            <input
-              className="input-terminal text-sm"
-              value={channel.baseUrl}
-              disabled={busy}
-              onChange={(e) => onUpdate(index, 'baseUrl', e.target.value)}
-              placeholder={
-                channel.protocol === 'gemini' || channel.protocol === 'anthropic'
-                  ? '官方接口可留空'
-                  : preset?.baseUrl || 'https://api.example.com/v1'
-              }
-            />
-          </div>
+          <Input
+            label="Base URL"
+            className="h-10"
+            value={channel.baseUrl}
+            disabled={busy}
+            onChange={(e) => onUpdate(index, 'baseUrl', e.target.value)}
+            placeholder={
+              channel.protocol === 'gemini' || channel.protocol === 'anthropic'
+                ? '官方接口可留空'
+                : preset?.baseUrl || 'https://api.example.com/v1'
+            }
+          />
 
-          <div>
-            <label className="mb-0.5 block text-[11px] text-muted">API Key</label>
-            <div className="flex items-center gap-1.5">
-              <input
+          <div className="flex flex-col">
+            <label className="mb-2 text-sm font-medium text-foreground">API Key</label>
+            <div className="flex items-center gap-2">
+              <Input
                 type={visibleKey ? 'text' : 'password'}
-                className="input-terminal text-sm flex-1"
+                className="h-10 flex-1"
                 value={channel.apiKey}
                 disabled={busy}
                 onChange={(e) => onUpdate(index, 'apiKey', e.target.value)}
                 placeholder={channel.protocol === 'ollama' ? '本地 Ollama 可留空' : '支持多个 Key 逗号分隔'}
               />
-              <button
-                type="button"
-                className="btn-secondary !p-1.5"
+              <Button
+                variant="secondary"
+                size="sm"
+                className="h-10 w-10 p-0 shrink-0"
                 disabled={busy}
                 onClick={() => onToggleKeyVisibility(index)}
                 title={visibleKey ? '隐藏' : '显示'}
-                aria-label={visibleKey ? '隐藏 API Key' : '显示 API Key'}
               >
                 <EyeToggleIcon visible={visibleKey} />
-              </button>
+              </Button>
             </div>
           </div>
 
-          <div>
-            <label className="mb-0.5 block text-[11px] text-muted">模型（逗号分隔）</label>
-            <input
-              className="input-terminal text-sm"
-              value={channel.models}
-              disabled={busy}
-              onChange={(e) => onUpdate(index, 'models', e.target.value)}
-              placeholder={preset?.placeholder || MODEL_PLACEHOLDERS[channel.protocol]}
-            />
-          </div>
+          <Input
+            label="模型（逗号分隔）"
+            className="h-10"
+            value={channel.models}
+            disabled={busy}
+            onChange={(e) => onUpdate(index, 'models', e.target.value)}
+            placeholder={preset?.placeholder || MODEL_PLACEHOLDERS[channel.protocol]}
+          />
 
-          <div className="flex items-center gap-2 pt-1">
-            <button
-              type="button"
-              className="btn-secondary text-xs"
-              disabled={busy}
+          <div className="flex items-center gap-3 pt-1">
+            <Button
+              variant="outline"
+              size="sm"
+              isLoading={testState?.status === 'loading'}
+              loadingText="测试中..."
               onClick={() => onTest(channel, index)}
             >
-              {testState?.status === 'loading' ? '测试中...' : '测试连接'}
-            </button>
+              测试连接
+            </Button>
             {testState?.text && (
-              <span className={`text-xs ${
-                testState.status === 'success' ? 'text-emerald-300'
-                : testState.status === 'error' ? 'text-rose-300'
-                : 'text-muted'
+              <span className={`text-xs font-medium ${
+                testState.status === 'success' ? 'text-success'
+                : testState.status === 'error' ? 'text-danger'
+                : 'text-muted-text'
               }`}>
                 {testState.text}
               </span>
@@ -867,84 +866,114 @@ export const LLMChannelEditor: React.FC<LLMChannelEditorProps> = ({
   };
 
   return (
-    <div className="rounded-xl border border-cyan/20 bg-elevated/50 p-4">
+    <div className="rounded-2xl border border-cyan/20 bg-elevated/40 backdrop-blur-md p-5 shadow-glow-cyan/5">
       <button
         type="button"
-        className="flex w-full items-center justify-between text-left"
+        className="flex w-full items-center justify-between text-left group"
         onClick={() => setIsCollapsed((previous) => !previous)}
       >
-        <div>
-          <h3 className="text-sm font-semibold text-white">AI 模型配置</h3>
-          <p className="mt-0.5 text-xs text-muted">
-            添加服务商渠道，填入 API Key 和模型名称即可。配置会自动同步到 .env 文件。
+        <div className="flex-1">
+          <div className="flex items-center gap-2">
+            <h3 className="text-base font-bold text-white tracking-tight">AI 模型渠道配置</h3>
+            <Badge variant="info" size="sm" className="opacity-0 group-hover:opacity-100 transition-opacity">Beta</Badge>
+          </div>
+          <p className="mt-1 text-sm text-secondary-text leading-relaxed max-w-2xl">
+            配置 LLM 渠道条目。启用后，您可以在下方「运行时参数」中指定主模型和 Fallback 策略。
           </p>
         </div>
-        <span className="text-xs text-muted">{isCollapsed ? '▶ 展开' : '▼ 收起'}</span>
+        <span className="text-xs font-mono text-cyan/60 group-hover:text-cyan transition-colors ml-4 bg-white/5 px-2 py-1 rounded">
+          {isCollapsed ? '[+] 展开' : '[-] 收起'}
+        </span>
       </button>
 
       {!isCollapsed && (
-        <div className="mt-4 space-y-5">
+        <div className="mt-6 space-y-6 animate-in fade-in duration-300">
           {/* --- Add Channel --- */}
-          <div className="flex items-center gap-2">
-            <button type="button" className="btn-secondary whitespace-nowrap" disabled={busy} onClick={addChannel}>
-              + 添加渠道
-            </button>
-            <Select
-              value={addPreset}
-              onChange={setAddPreset}
-              options={Object.entries(CHANNEL_PRESETS).map(([value, preset]) => ({
-                value,
-                label: preset.label,
-              }))}
+          <div className="flex flex-wrap items-end gap-3 p-4 rounded-xl bg-white/[0.03] border border-white/5">
+            <div className="flex-1 min-w-[200px]">
+              <label className="mb-2 block text-xs font-semibold text-muted-text uppercase tracking-wider">选择服务商快速添加</label>
+              <Select
+                value={addPreset}
+                onChange={setAddPreset}
+                options={Object.entries(CHANNEL_PRESETS).map(([value, preset]) => ({
+                  value,
+                  label: preset.label,
+                }))}
+                disabled={busy}
+                placeholder="选择服务商"
+                className="h-11"
+              />
+            </div>
+            <Button
+              variant="gradient"
+              className="h-11 px-6 shadow-glow-cyan/20"
               disabled={busy}
-              placeholder="选择服务商"
-              className="flex-1"
-            />
+              onClick={addChannel}
+            >
+              <svg className="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 4v16m8-8H4" />
+              </svg>
+              添加渠道
+            </Button>
           </div>
 
           {/* --- Channel List --- */}
-          <div className="space-y-1.5">
+          <div className="space-y-3">
             <div className="flex items-center justify-between px-1">
-              <span className="text-xs font-medium text-muted uppercase tracking-wider">渠道列表</span>
-              {channels.length > 0 && (
-                <span className="text-[10px] text-muted">{channels.filter(c => c.enabled).length}/{channels.length} 已启用</span>
-              )}
+              <span className="text-xs font-bold text-muted-text uppercase tracking-widest flex items-center gap-2">
+                已配置渠道
+                {channels.length > 0 && (
+                  <span className="text-[10px] font-mono bg-white/5 px-1.5 py-0.5 rounded text-cyan/70">
+                    {channels.filter(c => c.enabled).length}/{channels.length} ENABLED
+                  </span>
+                )}
+              </span>
             </div>
 
           {channels.length === 0 ? (
-            <div className="rounded-lg border border-dashed border-white/10 bg-card/20 px-4 py-6 text-center text-xs text-muted">
-              还没有渠道，选择服务商后点击「添加渠道」
+            <div className="rounded-xl border border-dashed border-white/10 bg-white/[0.01] px-4 py-10 text-center">
+              <div className="w-12 h-12 rounded-full bg-white/5 flex items-center justify-center mx-auto mb-3">
+                <svg className="w-6 h-6 text-muted-text/40" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
+                </svg>
+              </div>
+              <p className="text-sm text-muted-text">暂无配置，请从上方选择预设添加</p>
             </div>
-          ) : channels.map((channel, index) => (
-            <ChannelRow
-              key={index}
-              channel={channel}
-              index={index}
-              busy={busy}
-              visibleKey={Boolean(visibleKeys[index])}
-              expanded={Boolean(expandedRows[index])}
-              testState={testStates[index]}
-              onUpdate={updateChannel}
-              onRemove={removeChannel}
-              onToggleExpand={toggleExpand}
-              onToggleKeyVisibility={toggleKeyVisibility}
-              onTest={(ch, idx) => void handleTest(ch, idx)}
-            />
-          ))}
+          ) : (
+            <div className="grid gap-1">
+              {channels.map((channel, index) => (
+                <ChannelRow
+                  key={index}
+                  channel={channel}
+                  index={index}
+                  busy={busy}
+                  visibleKey={Boolean(visibleKeys[index])}
+                  expanded={Boolean(expandedRows[index])}
+                  testState={testStates[index]}
+                  onUpdate={updateChannel}
+                  onRemove={removeChannel}
+                  onToggleExpand={toggleExpand}
+                  onToggleKeyVisibility={toggleKeyVisibility}
+                  onTest={(ch, idx) => void handleTest(ch, idx)}
+                />
+              ))}
+            </div>
+          )}
           </div>
 
           {managesRuntimeConfig ? (
-            <div className="rounded-lg border border-white/8 bg-card/30 p-3">
-              <div className="mb-3 flex items-center justify-between">
-                <div>
-                  <span className="text-xs font-medium text-muted uppercase tracking-wider">运行时参数</span>
-                  <p className="mt-0.5 text-[11px] text-secondary">留空时自动推断</p>
-                </div>
+            <div className="rounded-xl border border-white/8 bg-white/[0.02] p-5 shadow-inner">
+              <div className="mb-5 border-b border-white/5 pb-3">
+                <span className="text-xs font-bold text-muted-text uppercase tracking-widest">运行时参数 (Runtime Strategy)</span>
+                <p className="mt-1 text-[11px] text-secondary-text">这些设置决定了系统在分析时如何选择具体的模型实例</p>
               </div>
 
-              <div className="mb-4">
-                <label className="mb-1 block text-xs text-muted">Temperature</label>
-                <div className="flex items-center gap-3">
+              <div className="mb-6">
+                <div className="flex items-center justify-between mb-2">
+                  <label className="text-sm font-medium text-foreground">Temperature (创造力)</label>
+                  <Badge variant="default" className="font-mono text-cyan">{runtimeConfig.temperature}</Badge>
+                </div>
+                <div className="flex items-center gap-4">
                   <input
                     type="range"
                     min="0"
@@ -953,94 +982,116 @@ export const LLMChannelEditor: React.FC<LLMChannelEditorProps> = ({
                     value={runtimeConfig.temperature}
                     disabled={busy}
                     onChange={(event) => setRuntimeConfig((previous) => ({ ...previous, temperature: event.target.value }))}
-                    className="h-1.5 flex-1 cursor-pointer appearance-none rounded-full bg-white/10 accent-cyan"
+                    className="h-1.5 flex-1 cursor-pointer appearance-none rounded-full bg-white/10 accent-cyan focus:outline-none"
                   />
-                  <span className="w-8 text-right text-sm text-secondary">{runtimeConfig.temperature}</span>
                 </div>
-                <p className="mt-1 text-[11px] text-secondary">
-                  控制模型输出随机性，0 为确定性输出，2 为最大随机性，推荐 0.7。
+                <p className="mt-2 text-[11px] text-muted-text leading-relaxed">
+                  0 为极度严谨，2 为最大随机性。股票分析建议设定在 <span className="text-cyan/80">0.3 - 0.7</span> 之间。
                 </p>
               </div>
 
               {availableModels.length === 0 ? (
-                <div className="rounded-lg border border-dashed border-white/10 bg-card/20 px-3 py-2 text-xs text-muted">
-                  先添加至少一个已启用渠道并填写模型，下面的主模型 / fallback / Vision 选项才会出现。
+                <div className="rounded-xl border border-dashed border-white/10 bg-white/[0.01] p-4 text-center text-xs text-muted-text">
+                  请先添加并启用至少一个包含可用模型的渠道
                 </div>
               ) : (
-                <div className="space-y-4">
-                  <div>
-                    <label className="mb-1 block text-xs text-muted">主模型</label>
-                    <Select
-                      value={runtimeConfig.primaryModel}
-                      onChange={setPrimaryModel}
-                      options={buildModelOptions(availableModels, runtimeConfig.primaryModel, '自动（使用第一个可用模型）')}
-                      disabled={busy}
-                      placeholder=""
-                    />
+                <div className="space-y-5">
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <div className="flex flex-col">
+                      <label className="mb-2 text-xs font-semibold text-muted-text uppercase tracking-wider">主模型 (Primary)</label>
+                      <Select
+                        className="h-10"
+                        value={runtimeConfig.primaryModel}
+                        onChange={setPrimaryModel}
+                        options={buildModelOptions(availableModels, runtimeConfig.primaryModel, '自动（使用第一个可用模型）')}
+                        disabled={busy}
+                        placeholder=""
+                      />
+                    </div>
+                    <div className="flex flex-col">
+                      <label className="mb-2 text-xs font-semibold text-muted-text uppercase tracking-wider">Vision 模型 (多模态)</label>
+                      <Select
+                        className="h-10"
+                        value={runtimeConfig.visionModel}
+                        onChange={(value) => setRuntimeConfig((previous) => ({ ...previous, visionModel: value }))}
+                        options={buildModelOptions(availableModels, runtimeConfig.visionModel, '自动（跟随 Vision 默认逻辑）')}
+                        disabled={busy}
+                        placeholder=""
+                      />
+                    </div>
                   </div>
 
                   <div>
-                    <label className="mb-2 block text-xs text-muted">Fallback 模型</label>
-                    <div className="space-y-2 rounded-lg border border-white/8 bg-card/20 p-3">
+                    <label className="mb-3 block text-xs font-semibold text-muted-text uppercase tracking-wider">备选队列 (Fallback Queue)</label>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-2 rounded-xl border border-white/5 bg-black/20 p-4">
                       {availableModels.map((model) => (
-                        <label key={model} className="flex items-center gap-2 text-sm text-secondary">
+                        <label key={model} className={`flex items-center gap-2.5 px-3 py-2 rounded-lg border transition-all cursor-pointer ${
+                          runtimeConfig.fallbackModels.includes(model)
+                            ? 'bg-cyan/5 border-cyan/30 text-white'
+                            : 'bg-transparent border-white/5 text-secondary-text hover:border-white/10'
+                        }`}>
                           <input
                             type="checkbox"
+                            className="w-4 h-4 rounded border-white/10 bg-card text-cyan focus:ring-cyan/20"
                             checked={runtimeConfig.fallbackModels.includes(model)}
                             disabled={busy || model === runtimeConfig.primaryModel}
                             onChange={() => toggleFallbackModel(model)}
                           />
-                          <span>{model}</span>
+                          <span className="text-xs truncate font-medium">{model}</span>
                         </label>
                       ))}
                     </div>
-                    <p className="mt-1 text-[11px] text-secondary">
-                      Fallback 只会在主模型失败时使用。主模型不会重复加入 fallback。
+                    <p className="mt-2 text-[11px] text-muted-text">
+                      当主模型响应失败时，将按选择顺序尝试上述备选模型。
                     </p>
-                  </div>
-
-                  <div>
-                    <label className="mb-1 block text-xs text-muted">Vision 模型</label>
-                    <Select
-                      value={runtimeConfig.visionModel}
-                      onChange={(value) => setRuntimeConfig((previous) => ({ ...previous, visionModel: value }))}
-                      options={buildModelOptions(availableModels, runtimeConfig.visionModel, '自动（跟随 Vision 默认逻辑）')}
-                      disabled={busy}
-                      placeholder=""
-                    />
                   </div>
                 </div>
               )}
             </div>
           ) : (
-            <div className="rounded-lg border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
-              当前已启用 `LITELLM_CONFIG`，主模型 / fallback / Vision / Temperature 继续在下方通用字段中管理；
-              这里仅保存渠道条目，不会覆盖 YAML 运行时选择。
+            <div className="rounded-xl border border-warning/20 bg-warning/5 px-4 py-3 flex items-start gap-3">
+              <svg className="w-5 h-5 text-warning shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <div className="text-xs text-warning/90 leading-relaxed">
+                <p className="font-bold mb-1 uppercase tracking-tight">Detecting LITELLM_CONFIG</p>
+                当前正在使用 YAML 文件管理模型映射。此处的「渠道」仅用于 API 密钥同步，模型优先级请在 YAML 中配置。
+              </div>
             </div>
           )}
 
-          <div className="flex flex-wrap items-center gap-2">
-            <button
-              type="button"
-              className="btn-primary"
-              disabled={busy || !hasChanges}
-              onClick={() => void handleSave()}
-            >
-              {isSaving ? '保存中...' : managesRuntimeConfig ? '保存 AI 配置' : '保存渠道配置'}
-            </button>
-            {!hasChanges ? (
-              <span className="text-xs text-muted">当前没有未保存的改动</span>
-            ) : null}
+          <div className="flex items-center justify-between pt-2 border-t border-white/5">
+            <div className="flex items-center gap-3">
+              <Button
+                variant="primary"
+                glow
+                className="px-8"
+                disabled={busy || !hasChanges}
+                onClick={() => void handleSave()}
+                isLoading={isSaving}
+                loadingText="正在保存..."
+              >
+                {managesRuntimeConfig ? '应用 AI 策略' : '保存渠道条目'}
+              </Button>
+              {!hasChanges && (
+                <span className="text-xs text-muted-text italic">无待保存更改</span>
+              )}
+            </div>
           </div>
 
-          {saveMessage?.type === 'success' ? (
-            <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-200">
-              {saveMessage.text}
+          {saveMessage?.type === 'success' && (
+            <div className="rounded-xl border border-success/30 bg-success/10 px-4 py-3 text-sm text-success animate-in slide-in-from-bottom-2">
+              <div className="flex items-center gap-2">
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" />
+                </svg>
+                {saveMessage.text}
+              </div>
             </div>
-          ) : null}
+          )}
 
-          {saveMessage?.type === 'local-error' ? (
-            <div className="rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-200">
+          {saveMessage?.type === 'local-error' && (
+            <div className="rounded-xl border border-danger/30 bg-danger/10 px-4 py-3 text-sm text-danger animate-in shake-1">
               {saveMessage.text}
             </div>
           ) : null}

--- a/apps/dsa-web/src/components/settings/SettingsAlert.tsx
+++ b/apps/dsa-web/src/components/settings/SettingsAlert.tsx
@@ -10,9 +10,9 @@ interface SettingsAlertProps {
 }
 
 const variantStyles: Record<NonNullable<SettingsAlertProps['variant']>, string> = {
-  error: 'border-red-500/35 bg-red-500/10 text-red-200',
-  success: 'border-emerald-500/35 bg-emerald-500/10 text-emerald-200',
-  warning: 'border-amber-500/35 bg-amber-500/10 text-amber-200',
+  error: 'border-danger/35 bg-danger/10 text-danger',
+  success: 'border-success/35 bg-success/10 text-success',
+  warning: 'border-warning/35 bg-warning/10 text-warning',
 };
 
 export const SettingsAlert: React.FC<SettingsAlertProps> = ({

--- a/apps/dsa-web/src/components/settings/SettingsField.tsx
+++ b/apps/dsa-web/src/components/settings/SettingsField.tsx
@@ -78,7 +78,7 @@ function renderFieldControl(
           disabled={disabled || !schema?.isEditable}
           onChange={(event) => onChange(event.target.checked ? 'true' : 'false')}
         />
-        <span className="text-sm text-secondary">{checked ? '已启用' : '未启用'}</span>
+        <span className="text-sm text-secondary-text">{checked ? '已启用' : '未启用'}</span>
       </label>
     );
   }
@@ -207,7 +207,7 @@ export const SettingsField: React.FC<SettingsFieldProps> = ({
       </div>
 
       {description ? (
-        <p className="mb-3 text-xs text-muted" title={description}>
+        <p className="mb-3 text-xs text-muted-text" title={description}>
           {description}
         </p>
       ) : null}
@@ -226,7 +226,7 @@ export const SettingsField: React.FC<SettingsFieldProps> = ({
       </div>
 
       {schema?.isSensitive ? (
-        <p className="mt-2 text-[11px] text-secondary">
+        <p className="mt-2 text-[11px] text-secondary-text">
           密钥默认隐藏，可点击眼睛图标查看明文。
           {isMultiValue ? ' 支持添加多个输入框进行增删。' : ''}
         </p>

--- a/apps/dsa-web/src/components/tasks/TaskPanel.tsx
+++ b/apps/dsa-web/src/components/tasks/TaskPanel.tsx
@@ -38,7 +38,7 @@ const TaskItem: React.FC<TaskItemProps> = ({ task }) => {
           </svg>
         ) : isPending ? (
           // 等待图标
-          <svg className="w-4 h-4 text-muted" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="w-4 h-4 text-muted-text" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path
               strokeLinecap="round"
               strokeLinejoin="round"
@@ -55,12 +55,12 @@ const TaskItem: React.FC<TaskItemProps> = ({ task }) => {
           <span className="text-sm font-medium text-white truncate">
             {task.stockName || task.stockCode}
           </span>
-          <span className="text-xs text-muted">
+          <span className="text-xs text-muted-text">
             {task.stockCode}
           </span>
         </div>
         {task.message && (
-          <p className="text-xs text-secondary truncate mt-0.5">
+          <p className="text-xs text-secondary-text truncate mt-0.5">
             {task.message}
           </p>
         )}
@@ -72,7 +72,7 @@ const TaskItem: React.FC<TaskItemProps> = ({ task }) => {
           className={`text-xs px-1.5 py-0.5 rounded ${
             isProcessing
               ? 'bg-cyan/20 text-cyan'
-              : 'bg-white/10 text-muted'
+              : 'bg-white/10 text-muted-text'
           }`}
         >
           {isProcessing ? '分析中' : '等待中'}
@@ -134,7 +134,7 @@ export const TaskPanel: React.FC<TaskPanelProps> = ({
           </svg>
           <span className="text-sm font-medium text-white">{title}</span>
         </div>
-        <div className="flex items-center gap-2 text-xs text-muted">
+        <div className="flex items-center gap-2 text-xs text-muted-text">
           {processingCount > 0 && (
             <span className="flex items-center gap-1">
               <span className="w-1.5 h-1.5 bg-cyan rounded-full animate-pulse" />

--- a/apps/dsa-web/src/index.css
+++ b/apps/dsa-web/src/index.css
@@ -1,50 +1,91 @@
 @import "tailwindcss";
 
-/* ============ CSS 变量 - 金融终端风格 ============ */
+/* =========================================
+   1. THEME VARIABLES (Base/Classic)
+   ========================================= */
 :root {
-  /* 主色调 - 青色系 */
+  /* Primary brand tones */
   --color-cyan: #00d4ff;
   --color-cyan-dim: #00a8cc;
   --color-cyan-glow: rgba(0, 212, 255, 0.4);
-  
-  /* 辅助色 - 紫色系 */
+
+  /* Secondary accent tones */
   --color-purple: #6f61f1;
   --color-purple-dim: #5a4ed4;
   --color-purple-glow: rgba(168, 85, 247, 0.3);
-  
-  /* 状态色 */
+
+  /* Status colors */
   --color-success: #00ff88;
   --color-warning: #ffaa00;
   --color-danger: #ff4466;
-  
-  /* 背景色 - 深黑系 */
+
+  /* Dark surface colors */
   --bg-base: #08080c;
   --bg-card: #0d0d14;
   --bg-elevated: #12121a;
   --bg-hover: #1a1a24;
-  
-  /* 边框色 */
+
+  /* Border colors */
   --border-dim: rgba(255, 255, 255, 0.06);
   --border-default: rgba(255, 255, 255, 0.1);
   --border-accent: rgba(0, 212, 255, 0.3);
-  --border-purple: rgba(47, 165, 245, 0.3);
-  
-  /* 文字色 */
+  --border-purple: rgba(168, 85, 247, 0.28);
+
+  /* Text colors */
   --text-primary: #ffffff;
   --text-secondary: #a0a0b0;
   --text-muted: #606070;
-  
-  /* 字体 */
-  font-family: 'Inter', 'SF Pro Display', system-ui, -apple-system, sans-serif;
+
+  /* Typography */
+  font-family:
+    "Inter",
+    "SF Pro Display",
+    "Segoe UI",
+    system-ui,
+    -apple-system,
+    sans-serif;
   line-height: 1.5;
   font-weight: 400;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  /* HSL tokens used by Tailwind-based components */
+
+  --background: 228 35% 7%;
+  --foreground: 210 33% 98%;
+  --card: 230 24% 10%;
+  --card-foreground: 210 33% 98%;
+  --popover: 230 24% 10%;
+  --popover-foreground: 210 33% 98%;
+  --primary: 190 100% 50%;
+  --primary-foreground: 228 35% 8%;
+  --secondary: 231 19% 15%;
+  --secondary-foreground: 210 33% 94%;
+  --muted: 230 18% 14%;
+  --muted-foreground: 228 13% 66%;
+  --accent: 231 18% 16%;
+  --accent-foreground: 210 33% 98%;
+  --destructive: 349 100% 63%;
+  --destructive-foreground: 210 33% 98%;
+  --border: 226 19% 20%;
+  --input: 226 19% 20%;
+  --ring: 190 100% 50%;
+  --radius: 1rem;
+  --elevated: 230 22% 12%;
+  --hover: 231 20% 16%;
+  --secondary-text: 228 16% 72%;
+  --muted-text: 228 10% 48%;
 }
 
-/* ============ 基础样式 ============ */
+/* =========================================
+   2. GLOBAL STYLES (from Classic)
+   ========================================= */
+
+/* ============ Financial Terminal Tokens ============ */
+
+/* ============ Base Styles ============ */
 body {
   margin: 0;
   min-width: 320px;
@@ -53,7 +94,7 @@ body {
   color: var(--text-primary);
 }
 
-/* ============ 终端卡片样式 ============ */
+/* ============ Terminal Card Styles ============ */
 .terminal-card {
   background: var(--bg-card);
   border: 1px solid var(--border-default);
@@ -63,7 +104,7 @@ body {
 }
 
 .terminal-card::before {
-  content: '';
+  content: "";
   position: absolute;
   inset: 0;
   border-radius: 12px;
@@ -74,8 +115,12 @@ body {
     rgba(0, 212, 255, 0.1) 50%,
     rgba(85, 198, 247, 0.2) 100%
   );
-  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
-  mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
   -webkit-mask-composite: xor;
   mask-composite: exclude;
   pointer-events: none;
@@ -90,7 +135,7 @@ body {
   box-shadow: 0 0 30px rgba(0, 212, 255, 0.1);
 }
 
-/* ============ 渐变边框卡片 ============ */
+/* ============ Gradient Border Card ============ */
 .gradient-border-card {
   background: var(--bg-card);
   border-radius: 12px;
@@ -99,7 +144,7 @@ body {
 }
 
 .gradient-border-card::before {
-  content: '';
+  content: "";
   position: absolute;
   inset: 0;
   border-radius: 12px;
@@ -110,8 +155,12 @@ body {
     rgba(168, 85, 247, 0.1) 50%,
     rgba(0, 212, 255, 0.2) 100%
   );
-  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
-  mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
   -webkit-mask-composite: xor;
   mask-composite: exclude;
   pointer-events: none;
@@ -123,7 +172,7 @@ body {
   height: 100%;
 }
 
-/* ============ 毛玻璃卡片 ============ */
+/* ============ Glass Card ============ */
 .glass-card {
   background: rgba(13, 13, 20, 0.7);
   backdrop-filter: blur(12px);
@@ -135,7 +184,7 @@ body {
 }
 
 .glass-card::before {
-  content: '';
+  content: "";
   position: absolute;
   inset: 0;
   border-radius: 12px;
@@ -146,16 +195,20 @@ body {
     rgba(0, 212, 255, 0.15) 50%,
     rgba(85, 209, 247, 0.1) 100%
   );
-  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
-  mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
   -webkit-mask-composite: xor;
   mask-composite: exclude;
   pointer-events: none;
 }
 
-/* 毛玻璃卡片 - 顶部高光 */
+/* Glass card top highlight */
 .glass-card::after {
-  content: '';
+  content: "";
   position: absolute;
   top: 0;
   left: 10%;
@@ -170,7 +223,7 @@ body {
   pointer-events: none;
 }
 
-/* ============ 历史记录列表项 ============ */
+/* ============ History List Item ============ */
 .history-item {
   display: flex;
   align-items: center;
@@ -185,7 +238,7 @@ body {
 }
 
 .history-item::before {
-  content: '';
+  content: "";
   position: absolute;
   inset: 0;
   border-radius: 8px;
@@ -196,8 +249,12 @@ body {
     transparent 50%,
     rgba(0, 212, 255, 0.1) 100%
   );
-  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
-  mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
   -webkit-mask-composite: xor;
   mask-composite: exclude;
   pointer-events: none;
@@ -229,7 +286,7 @@ body {
   );
 }
 
-/* ============ 浮动 Dock 导航栏 ============ */
+/* ============ Floating Dock Navigation ============ */
 .dock-nav {
   position: fixed;
   left: 24px;
@@ -244,14 +301,16 @@ body {
   width: 72px;
   padding: 14px 10px;
   border-radius: 26px;
-  /* 调整背景色：使用更深的半透明背景，减少突兀感 */
+  /* Use a darker translucent surface to reduce contrast jumps. */
   background: rgba(18, 18, 26, 0.6);
-  /* 边框调淡 */
+  /* Keep the border subtle. */
   border: 1px solid rgba(255, 255, 255, 0.06);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
-  /* 阴影优化：更柔和的深色阴影 */
-  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  /* Soften the shadow stack. */
+  box-shadow:
+    0 12px 40px rgba(0, 0, 0, 0.4),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -260,34 +319,43 @@ body {
 }
 
 .dock-surface::before {
-  content: '';
+  content: "";
   position: absolute;
   inset: 0;
   border-radius: inherit;
   padding: 1px;
-  /* 渐变边框优化：更低调的颜色 */
+  /* Use a more restrained border gradient. */
   background: linear-gradient(
     180deg,
     rgba(255, 255, 255, 0.1) 0%,
     rgba(255, 255, 255, 0.05) 100%
   );
-  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
-  mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
   -webkit-mask-composite: xor;
   mask-composite: exclude;
   pointer-events: none;
   opacity: 0.5;
 }
 
-/* 顶部高光保留，但减弱 */
+/* Keep the top highlight, but tone it down. */
 .dock-surface::after {
-  content: '';
+  content: "";
   position: absolute;
   top: 10px;
   left: 12px;
   right: 12px;
   height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.15), transparent);
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(255, 255, 255, 0.15),
+    transparent
+  );
   pointer-events: none;
   opacity: 0.4;
 }
@@ -299,12 +367,18 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  /* Logo 渐变微调 */
-  background: linear-gradient(135deg, rgba(51, 110, 168, 0.45) 0%, #367db5 100%);
+  /* Fine-tuned logo gradient. */
+  background: linear-gradient(
+    135deg,
+    rgba(51, 110, 168, 0.45) 0%,
+    #367db5 100%
+  );
   color: #04141d;
   text-decoration: none;
   box-shadow: 0 8px 16px rgba(0, 212, 255, 0.25);
-  transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.2s ease;
+  transition:
+    transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1),
+    box-shadow 0.2s ease;
 }
 
 .dock-logo:hover {
@@ -342,20 +416,24 @@ body {
   overflow: hidden;
 }
 
-/* 动态交互：渐变背景层 */
+/* Interactive gradient background layer */
 .dock-item::before {
-  content: '';
+  content: "";
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0.02));
+  background: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.1),
+    rgba(255, 255, 255, 0.02)
+  );
   opacity: 0;
   transition: opacity 0.3s ease;
 }
 
-/* 动态交互：底部光晕 */
+/* Interactive bottom glow */
 .dock-item::after {
-  content: '';
+  content: "";
   position: absolute;
   bottom: 0;
   left: 50%;
@@ -368,7 +446,7 @@ body {
   transition: all 0.4s ease;
 }
 
-/* Hover 状态 - 柔和的渐变和光晕 */
+/* Hover state with softer gradient and glow */
 .dock-item:hover {
   color: var(--text-primary);
   transform: translateY(-2px);
@@ -384,27 +462,33 @@ body {
   transform: translateX(-50%) translateY(40%);
 }
 
-/* 激活状态 - 使用 Logo 同款渐变风格及交互 */
+/* Active state reuses the logo gradient treatment */
 .dock-item.is-active {
-  /* 复用 Logo 的渐变背景 */
-  background: linear-gradient(135deg, rgba(51, 110, 168, 0.45) 0%, #367db5 100%);
-  color: #04141d; /* 深色图标 */
+  /* Reuse the logo gradient background. */
+  background: linear-gradient(
+    135deg,
+    rgba(51, 110, 168, 0.45) 0%,
+    #367db5 100%
+  );
+  color: #04141d; /* Dark icon color. */
   border-color: transparent;
   box-shadow: 0 8px 16px rgba(0, 212, 255, 0.25);
-  /* Logo 的弹跳动画曲线 */
-  transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.2s ease;
+  /* Match the logo bounce timing curve. */
+  transition:
+    transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1),
+    box-shadow 0.2s ease;
 }
 
 .dock-item.is-active:hover {
-  /* Logo 的悬浮交互：放大而非上浮 */
+  /* Scale the active item instead of lifting it. */
   transform: scale(1.05);
   box-shadow: 0 10px 20px rgba(0, 212, 255, 0.35);
-  /* 保持颜色 */
+  /* Preserve the active icon color. */
   color: #04141d;
   border-color: transparent;
 }
 
-/* 激活状态下隐藏通用的 hover 效果元素，避免冲突 */
+/* Hide shared hover effects while the item is active. */
 .dock-item.is-active::after,
 .dock-item.is-active::before {
   opacity: 0 !important;
@@ -433,7 +517,7 @@ body {
   padding-left: 120px;
 }
 
-/* ============ 标题样式 ============ */
+/* ============ Title Styles ============ */
 .label-uppercase {
   font-size: 11px;
   font-weight: 600;
@@ -450,7 +534,7 @@ body {
   color: transparent;
 }
 
-/* ============ 环形仪表盘 ============ */
+/* ============ Circular Gauge ============ */
 .gauge-ring {
   filter: drop-shadow(0 0 8px var(--color-cyan-glow));
 }
@@ -471,7 +555,7 @@ body {
   opacity: 0.6;
 }
 
-/* ============ 输入框样式 ============ */
+/* ============ Input Styles ============ */
 .input-terminal {
   width: 100%;
   padding: 10px 14px;
@@ -497,9 +581,13 @@ body {
   border-color: rgba(255, 255, 255, 0.15);
 }
 
-/* ============ 按钮样式 ============ */
+/* ============ Button Styles ============ */
 .btn-primary {
-  background: linear-gradient(135deg, var(--color-cyan) 0%, var(--color-cyan-dim) 100%);
+  background: linear-gradient(
+    135deg,
+    var(--color-cyan) 0%,
+    var(--color-cyan-dim) 100%
+  );
   color: #000;
   font-weight: 600;
   padding: 10px 20px;
@@ -543,7 +631,7 @@ body {
   color: var(--color-cyan);
 }
 
-/* ============ 徽章样式 ============ */
+/* ============ Badge Styles ============ */
 .badge {
   display: inline-flex;
   align-items: center;
@@ -575,7 +663,7 @@ body {
   color: var(--color-danger);
 }
 
-/* ============ 列表项样式 ============ */
+/* ============ List Item Styles ============ */
 .list-item {
   display: flex;
   align-items: center;
@@ -592,7 +680,7 @@ body {
   border-color: var(--border-dim);
 }
 
-/* ============ Feed 项目样式 ============ */
+/* ============ Feed Item Styles ============ */
 .feed-item {
   padding: 10px 0;
   border-left: 2px solid var(--border-accent);
@@ -603,7 +691,7 @@ body {
   margin-top: 8px;
 }
 
-/* ============ 自定义滚动条 ============ */
+/* ============ Custom Scrollbar ============ */
 ::-webkit-scrollbar {
   width: 6px;
   height: 6px;
@@ -622,18 +710,22 @@ body {
   background: rgba(255, 255, 255, 0.2);
 }
 
-/* ============ 动画效果 ============ */
+/* ============ Animations ============ */
 @keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 @keyframes slideUp {
-  from { 
+  from {
     opacity: 0;
     transform: translateY(10px);
   }
-  to { 
+  to {
     opacity: 1;
     transform: translateY(0);
   }
@@ -651,7 +743,8 @@ body {
 }
 
 @keyframes pulse-glow {
-  0%, 100% {
+  0%,
+  100% {
     box-shadow: 0 0 20px var(--color-cyan-glow);
   }
   50% {
@@ -660,8 +753,12 @@ body {
 }
 
 @keyframes spin {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .animate-fade-in {
@@ -684,23 +781,47 @@ body {
   animation: spin 1s linear infinite;
 }
 
-/* ============ 工具类 ============ */
-.text-cyan { color: var(--color-cyan); }
-.text-purple { color: var(--color-purple); }
-.text-success { color: var(--color-success); }
-.text-danger { color: var(--color-danger); }
-.text-warning { color: var(--color-warning); }
-.text-muted { color: var(--text-muted); }
-.text-secondary { color: var(--text-secondary); }
+/* ============ Utilities ============ */
+.text-cyan {
+  color: var(--color-cyan);
+}
+.text-purple {
+  color: var(--color-purple);
+}
+.text-success {
+  color: var(--color-success);
+}
+.text-danger {
+  color: var(--color-danger);
+}
+.text-warning {
+  color: var(--color-warning);
+}
+.text-muted {
+  color: var(--text-muted);
+}
+.text-secondary {
+  color: var(--text-secondary);
+}
 
-.bg-base { background: var(--bg-base); }
-.bg-card { background: var(--bg-card); }
-.bg-elevated { background: var(--bg-elevated); }
+.bg-base {
+  background: var(--bg-base);
+}
+.bg-card {
+  background: var(--bg-card);
+}
+.bg-elevated {
+  background: var(--bg-elevated);
+}
 
-.border-accent { border-color: var(--border-accent); }
-.border-purple { border-color: var(--border-purple); }
+.border-accent {
+  border-color: var(--border-accent);
+}
+.border-purple {
+  border-color: var(--border-purple);
+}
 
-/* 发光效果 */
+/* Glow utilities */
 .glow-cyan {
   box-shadow: 0 0 20px var(--color-cyan-glow);
 }
@@ -709,7 +830,7 @@ body {
   box-shadow: 0 0 20px var(--color-purple-glow);
 }
 
-/* ============ 响应式 ============ */
+/* ============ Responsive ============ */
 @media (max-width: 768px) {
   .dock-nav {
     left: 12px;
@@ -735,5 +856,373 @@ body {
 
   .dock-safe-area {
     padding-left: 88px;
+  }
+}
+
+/* =========================================
+   4. NEW UI COMPONENT UTILITIES (from Terminal PR)
+   ========================================= */
+
+a {
+  color: inherit;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+.terminal-card {
+  position: relative;
+  overflow: hidden;
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(
+    180deg,
+    rgba(16, 16, 24, 0.96),
+    rgba(11, 11, 18, 0.96)
+  );
+  box-shadow: 0 18px 48px rgba(3, 8, 20, 0.18);
+}
+
+.terminal-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 1rem;
+  padding: 1px;
+  background: linear-gradient(
+    135deg,
+    rgba(0, 212, 255, 0.18) 0%,
+    rgba(111, 97, 241, 0.08) 52%,
+    rgba(0, 212, 255, 0.18) 100%
+  );
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  pointer-events: none;
+}
+
+.terminal-card-hover {
+  transition:
+    transform 0.24s ease,
+    box-shadow 0.24s ease,
+    border-color 0.24s ease;
+}
+
+.terminal-card-hover:hover {
+  transform: translateY(-1px);
+  border-color: rgba(0, 212, 255, 0.22);
+  box-shadow: 0 24px 56px rgba(3, 8, 20, 0.26);
+}
+
+.gradient-border-card {
+  position: relative;
+  border-radius: 1rem;
+  padding: 1px;
+  background: linear-gradient(
+    180deg,
+    rgba(0, 212, 255, 0.28) 0%,
+    rgba(111, 97, 241, 0.12) 50%,
+    rgba(255, 255, 255, 0.05) 100%
+  );
+  box-shadow: 0 18px 48px rgba(3, 8, 20, 0.2);
+}
+
+.gradient-border-card-inner {
+  height: 100%;
+  border-radius: calc(1rem - 1px);
+  background: linear-gradient(
+    180deg,
+    rgba(14, 14, 22, 0.98),
+    rgba(10, 10, 16, 0.98)
+  );
+}
+
+.glass-card {
+  position: relative;
+  overflow: hidden;
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(15, 15, 24, 0.72);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  box-shadow: 0 18px 48px rgba(3, 8, 20, 0.22);
+}
+
+.glass-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 1rem;
+  padding: 1px;
+  background: linear-gradient(
+    135deg,
+    rgba(0, 212, 255, 0.22) 0%,
+    rgba(111, 97, 241, 0.12) 50%,
+    rgba(255, 255, 255, 0.03) 100%
+  );
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  pointer-events: none;
+}
+
+.glass-card::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 14%;
+  right: 14%;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.14) 50%,
+    transparent 100%
+  );
+  pointer-events: none;
+}
+
+.history-item {
+  position: relative;
+  display: flex;
+  cursor: pointer;
+  align-items: center;
+  overflow: hidden;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  background: rgba(18, 18, 26, 0.54);
+  padding: 10px 12px;
+  transition: all 0.2s ease;
+}
+
+.history-item::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 8px;
+  padding: 1px;
+  background: linear-gradient(
+    135deg,
+    rgba(85, 185, 247, 0.15) 0%,
+    transparent 50%,
+    rgba(0, 212, 255, 0.1) 100%
+  );
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  pointer-events: none;
+}
+
+.history-item:hover {
+  transform: translateX(2px);
+  border-color: rgba(255, 255, 255, 0.08);
+  background: rgba(26, 26, 36, 0.82);
+}
+
+.history-item:hover::before {
+  opacity: 1;
+}
+
+.history-item.active {
+  border-color: rgba(0, 212, 255, 0.25);
+  background: rgba(0, 212, 255, 0.08);
+}
+
+.history-item.active::before {
+  opacity: 1;
+  background: linear-gradient(
+    135deg,
+    rgba(0, 212, 255, 0.3) 0%,
+    rgba(168, 85, 247, 0.15) 100%
+  );
+}
+
+.dock-items {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.dock-item {
+  position: relative;
+  display: inline-flex;
+  height: 46px;
+  width: 46px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-muted);
+  transition: all 0.22s ease;
+}
+
+.dock-item::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(
+    135deg,
+    rgba(0, 212, 255, 0.12),
+    rgba(111, 97, 241, 0.08)
+  );
+  opacity: 0;
+  transition: opacity 0.22s ease;
+}
+
+.dock-item:hover {
+  transform: translateY(-1px);
+  border-color: rgba(0, 212, 255, 0.22);
+  background: rgba(0, 212, 255, 0.08);
+  color: var(--text-primary);
+}
+
+.dock-item:hover::before {
+  opacity: 1;
+}
+
+.dock-item.is-active {
+  border-color: rgba(0, 212, 255, 0.24);
+  background: linear-gradient(
+    135deg,
+    rgba(0, 212, 255, 0.2),
+    rgba(111, 97, 241, 0.16)
+  );
+  color: #fff;
+  box-shadow:
+    0 0 0 1px rgba(0, 212, 255, 0.1),
+    0 14px 32px rgba(0, 212, 255, 0.14);
+}
+
+.dock-item.is-placeholder,
+.dock-item[disabled] {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.label-uppercase {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.btn-primary,
+.btn-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 0.9rem;
+  padding: 0.7rem 1.1rem;
+  font-weight: 600;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease,
+    border-color 0.2s ease,
+    background 0.2s ease,
+    color 0.2s ease;
+}
+
+.btn-primary {
+  border: 1px solid rgba(0, 212, 255, 0.26);
+  background: linear-gradient(
+    135deg,
+    rgba(0, 212, 255, 0.96),
+    rgba(0, 168, 204, 0.96)
+  );
+  color: #041118;
+  box-shadow: 0 12px 28px rgba(0, 212, 255, 0.2);
+}
+
+.btn-primary:hover {
+  transform: translateY(-1px);
+  filter: brightness(1.04);
+  box-shadow: 0 18px 34px rgba(0, 212, 255, 0.22);
+}
+
+.btn-secondary {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text-secondary);
+}
+
+.btn-secondary:hover {
+  transform: translateY(-1px);
+  border-color: var(--border-accent);
+  background: rgba(0, 212, 255, 0.06);
+  color: #fff;
+}
+
+.btn-primary:disabled,
+.btn-secondary:disabled {
+  cursor: not-allowed;
+  opacity: 0.58;
+  box-shadow: none;
+  transform: none;
+}
+
+.gauge-ring {
+  transform: translateZ(0);
+}
+
+.text-muted {
+  color: var(--text-muted);
+}
+.text-secondary {
+  color: var(--text-secondary);
+}
+.bg-base {
+  background: var(--bg-base);
+}
+.bg-card {
+  background: var(--bg-card);
+}
+.bg-elevated {
+  background: var(--bg-elevated);
+}
+.bg-hover {
+  background: var(--bg-hover);
+}
+.border-accent {
+  border-color: var(--border-accent);
+}
+
+@media (max-width: 768px) {
+  .dock-items {
+    gap: 8px;
+  }
+
+  .dock-item {
+    width: 42px;
+    height: 42px;
+    border-radius: 12px;
   }
 }

--- a/apps/dsa-web/src/index.css
+++ b/apps/dsa-web/src/index.css
@@ -33,8 +33,8 @@
 
   /* Text colors */
   --text-primary: #ffffff;
-  --text-secondary: #a0a0b0;
-  --text-muted: #606070;
+  --text-secondary-text: #a0a0b0;
+  --text-muted-text: #606070;
 
   /* Typography */
   font-family:
@@ -92,198 +92,6 @@ body {
   min-height: 100vh;
   background: var(--bg-base);
   color: var(--text-primary);
-}
-
-/* ============ Terminal Card Styles ============ */
-.terminal-card {
-  background: var(--bg-card);
-  border: 1px solid var(--border-default);
-  border-radius: 12px;
-  position: relative;
-  overflow: hidden;
-}
-
-.terminal-card::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: 12px;
-  padding: 1px;
-  background: linear-gradient(
-    135deg,
-    rgba(85, 198, 247, 0.2) 0%,
-    rgba(0, 212, 255, 0.1) 50%,
-    rgba(85, 198, 247, 0.2) 100%
-  );
-  -webkit-mask:
-    linear-gradient(#fff 0 0) content-box,
-    linear-gradient(#fff 0 0);
-  mask:
-    linear-gradient(#fff 0 0) content-box,
-    linear-gradient(#fff 0 0);
-  -webkit-mask-composite: xor;
-  mask-composite: exclude;
-  pointer-events: none;
-}
-
-.terminal-card-hover {
-  transition: all 0.3s ease;
-}
-
-.terminal-card-hover:hover {
-  border-color: var(--border-accent);
-  box-shadow: 0 0 30px rgba(0, 212, 255, 0.1);
-}
-
-/* ============ Gradient Border Card ============ */
-.gradient-border-card {
-  background: var(--bg-card);
-  border-radius: 12px;
-  position: relative;
-  padding: 1px;
-}
-
-.gradient-border-card::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: 12px;
-  padding: 1px;
-  background: linear-gradient(
-    180deg,
-    rgba(67, 178, 246, 0.4) 0%,
-    rgba(168, 85, 247, 0.1) 50%,
-    rgba(0, 212, 255, 0.2) 100%
-  );
-  -webkit-mask:
-    linear-gradient(#fff 0 0) content-box,
-    linear-gradient(#fff 0 0);
-  mask:
-    linear-gradient(#fff 0 0) content-box,
-    linear-gradient(#fff 0 0);
-  -webkit-mask-composite: xor;
-  mask-composite: exclude;
-  pointer-events: none;
-}
-
-.gradient-border-card-inner {
-  background: var(--bg-card);
-  border-radius: 11px;
-  height: 100%;
-}
-
-/* ============ Glass Card ============ */
-.glass-card {
-  background: rgba(13, 13, 20, 0.7);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 12px;
-  position: relative;
-  overflow: hidden;
-}
-
-.glass-card::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: 12px;
-  padding: 1px;
-  background: linear-gradient(
-    135deg,
-    rgba(85, 209, 247, 0.25) 0%,
-    rgba(0, 212, 255, 0.15) 50%,
-    rgba(85, 209, 247, 0.1) 100%
-  );
-  -webkit-mask:
-    linear-gradient(#fff 0 0) content-box,
-    linear-gradient(#fff 0 0);
-  mask:
-    linear-gradient(#fff 0 0) content-box,
-    linear-gradient(#fff 0 0);
-  -webkit-mask-composite: xor;
-  mask-composite: exclude;
-  pointer-events: none;
-}
-
-/* Glass card top highlight */
-.glass-card::after {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 10%;
-  right: 10%;
-  height: 1px;
-  background: linear-gradient(
-    90deg,
-    transparent 0%,
-    rgba(255, 255, 255, 0.15) 50%,
-    transparent 100%
-  );
-  pointer-events: none;
-}
-
-/* ============ History List Item ============ */
-.history-item {
-  display: flex;
-  align-items: center;
-  padding: 10px 12px;
-  border-radius: 8px;
-  background: rgba(18, 18, 26, 0.5);
-  border: 1px solid rgba(255, 255, 255, 0.04);
-  transition: all 0.2s ease;
-  cursor: pointer;
-  position: relative;
-  overflow: hidden;
-}
-
-.history-item::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: 8px;
-  padding: 1px;
-  background: linear-gradient(
-    135deg,
-    rgba(85, 185, 247, 0.15) 0%,
-    transparent 50%,
-    rgba(0, 212, 255, 0.1) 100%
-  );
-  -webkit-mask:
-    linear-gradient(#fff 0 0) content-box,
-    linear-gradient(#fff 0 0);
-  mask:
-    linear-gradient(#fff 0 0) content-box,
-    linear-gradient(#fff 0 0);
-  -webkit-mask-composite: xor;
-  mask-composite: exclude;
-  pointer-events: none;
-  opacity: 0;
-  transition: opacity 0.2s ease;
-}
-
-.history-item:hover {
-  background: rgba(26, 26, 36, 0.8);
-  border-color: rgba(255, 255, 255, 0.08);
-  transform: translateX(2px);
-}
-
-.history-item:hover::before {
-  opacity: 1;
-}
-
-.history-item.active {
-  background: rgba(0, 212, 255, 0.08);
-  border-color: rgba(0, 212, 255, 0.25);
-}
-
-.history-item.active::before {
-  opacity: 1;
-  background: linear-gradient(
-    135deg,
-    rgba(0, 212, 255, 0.3) 0%,
-    rgba(168, 85, 247, 0.15) 100%
-  );
 }
 
 /* ============ Floating Dock Navigation ============ */
@@ -399,133 +207,11 @@ body {
   margin-top: auto;
 }
 
-.dock-item {
-  width: 48px;
-  height: 48px;
-  border-radius: 14px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--text-muted);
-  background: transparent;
-  border: 1px solid transparent;
-  text-decoration: none;
-  transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
-  position: relative;
-  cursor: pointer;
-  overflow: hidden;
-}
-
-/* Interactive gradient background layer */
-.dock-item::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  background: linear-gradient(
-    135deg,
-    rgba(255, 255, 255, 0.1),
-    rgba(255, 255, 255, 0.02)
-  );
-  opacity: 0;
-  transition: opacity 0.3s ease;
-}
-
-/* Interactive bottom glow */
-.dock-item::after {
-  content: "";
-  position: absolute;
-  bottom: 0;
-  left: 50%;
-  transform: translateX(-50%) translateY(100%);
-  width: 60%;
-  height: 40%;
-  background: radial-gradient(circle, rgba(0, 212, 255, 0.4), transparent 70%);
-  filter: blur(8px);
-  opacity: 0;
-  transition: all 0.4s ease;
-}
-
-/* Hover state with softer gradient and glow */
-.dock-item:hover {
-  color: var(--text-primary);
-  transform: translateY(-2px);
-  border-color: rgba(255, 255, 255, 0.08);
-}
-
-.dock-item:hover::before {
-  opacity: 1;
-}
-
-.dock-item:hover::after {
-  opacity: 0.6;
-  transform: translateX(-50%) translateY(40%);
-}
-
-/* Active state reuses the logo gradient treatment */
-.dock-item.is-active {
-  /* Reuse the logo gradient background. */
-  background: linear-gradient(
-    135deg,
-    rgba(51, 110, 168, 0.45) 0%,
-    #367db5 100%
-  );
-  color: #04141d; /* Dark icon color. */
-  border-color: transparent;
-  box-shadow: 0 8px 16px rgba(0, 212, 255, 0.25);
-  /* Match the logo bounce timing curve. */
-  transition:
-    transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1),
-    box-shadow 0.2s ease;
-}
-
-.dock-item.is-active:hover {
-  /* Scale the active item instead of lifting it. */
-  transform: scale(1.05);
-  box-shadow: 0 10px 20px rgba(0, 212, 255, 0.35);
-  /* Preserve the active icon color. */
-  color: #04141d;
-  border-color: transparent;
-}
-
-/* Hide shared hover effects while the item is active. */
-.dock-item.is-active::after,
-.dock-item.is-active::before {
-  opacity: 0 !important;
-}
-
-.dock-item.is-placeholder,
-.dock-item[disabled] {
-  color: var(--text-muted);
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.dock-item.is-placeholder:hover,
-.dock-item[disabled]:hover {
-  transform: none;
-  background: transparent;
-  border-color: transparent;
-}
-
-.dock-item.is-placeholder:hover::before,
-.dock-item.is-placeholder:hover::after {
-  opacity: 0;
-}
-
 .dock-safe-area {
   padding-left: 120px;
 }
 
 /* ============ Title Styles ============ */
-.label-uppercase {
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--color-purple);
-}
-
 .title-gradient {
   background: linear-gradient(90deg, #ffffff 0%, #a0a0b0 100%);
   -webkit-background-clip: text;
@@ -537,6 +223,7 @@ body {
 /* ============ Circular Gauge ============ */
 .gauge-ring {
   filter: drop-shadow(0 0 8px var(--color-cyan-glow));
+  transform: translateZ(0);
 }
 
 .gauge-track {
@@ -569,7 +256,7 @@ body {
 }
 
 .input-terminal::placeholder {
-  color: var(--text-muted);
+  color: var(--text-muted-text);
 }
 
 .input-terminal:focus {
@@ -579,56 +266,6 @@ body {
 
 .input-terminal:hover:not(:focus) {
   border-color: rgba(255, 255, 255, 0.15);
-}
-
-/* ============ Button Styles ============ */
-.btn-primary {
-  background: linear-gradient(
-    135deg,
-    var(--color-cyan) 0%,
-    var(--color-cyan-dim) 100%
-  );
-  color: #000;
-  font-weight: 600;
-  padding: 10px 20px;
-  border-radius: 8px;
-  border: none;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  font-size: 13px;
-}
-
-.btn-primary:hover {
-  box-shadow: 0 0 20px var(--color-cyan-glow);
-  transform: translateY(-1px);
-}
-
-.btn-primary:active {
-  transform: translateY(0);
-}
-
-.btn-primary:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-  transform: none;
-  box-shadow: none;
-}
-
-.btn-secondary {
-  background: transparent;
-  color: var(--text-secondary);
-  font-weight: 500;
-  padding: 10px 20px;
-  border-radius: 8px;
-  border: 1px solid var(--border-default);
-  cursor: pointer;
-  transition: all 0.2s ease;
-  font-size: 13px;
-}
-
-.btn-secondary:hover {
-  border-color: var(--border-accent);
-  color: var(--color-cyan);
 }
 
 /* ============ Badge Styles ============ */
@@ -711,26 +348,6 @@ body {
 }
 
 /* ============ Animations ============ */
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-@keyframes slideUp {
-  from {
-    opacity: 0;
-    transform: translateY(10px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
 @keyframes slideInRight {
   from {
     opacity: 0;
@@ -797,11 +414,11 @@ body {
 .text-warning {
   color: var(--color-warning);
 }
-.text-muted {
-  color: var(--text-muted);
+.text-muted-text {
+  color: var(--text-muted-text);
 }
-.text-secondary {
-  color: var(--text-secondary);
+.text-secondary-text {
+  color: var(--text-secondary-text);
 }
 
 .bg-base {
@@ -878,11 +495,11 @@ textarea {
   position: relative;
   overflow: hidden;
   border-radius: 1rem;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--border-dim);
   background: linear-gradient(
     180deg,
-    rgba(16, 16, 24, 0.96),
-    rgba(11, 11, 18, 0.96)
+    hsl(var(--card) / 0.96),
+    hsl(var(--background) / 0.96)
   );
   box-shadow: 0 18px 48px rgba(3, 8, 20, 0.18);
 }
@@ -941,8 +558,8 @@ textarea {
   border-radius: calc(1rem - 1px);
   background: linear-gradient(
     180deg,
-    rgba(14, 14, 22, 0.98),
-    rgba(10, 10, 16, 0.98)
+    hsl(var(--elevated) / 0.98),
+    hsl(var(--card) / 0.98)
   );
 }
 
@@ -951,7 +568,7 @@ textarea {
   overflow: hidden;
   border-radius: 1rem;
   border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(15, 15, 24, 0.72);
+  background: hsl(var(--card) / 0.72);
   backdrop-filter: blur(18px);
   -webkit-backdrop-filter: blur(18px);
   box-shadow: 0 18px 48px rgba(3, 8, 20, 0.22);
@@ -1003,8 +620,8 @@ textarea {
   align-items: center;
   overflow: hidden;
   border-radius: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.04);
-  background: rgba(18, 18, 26, 0.54);
+  border: 1px solid var(--border-dim);
+  background: hsl(var(--elevated) / 0.54);
   padding: 10px 12px;
   transition: all 0.2s ease;
 }
@@ -1069,7 +686,10 @@ textarea {
   border-radius: 14px;
   border: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(255, 255, 255, 0.04);
-  color: var(--text-muted);
+  color: var(--text-muted-text);
+  cursor: pointer;
+  overflow: hidden;
+  text-decoration: none;
   transition: all 0.22s ease;
 }
 
@@ -1087,6 +707,20 @@ textarea {
   transition: opacity 0.22s ease;
 }
 
+.dock-item::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  height: 40%;
+  width: 60%;
+  transform: translateX(-50%) translateY(100%);
+  background: radial-gradient(circle, rgba(0, 212, 255, 0.4), transparent 70%);
+  filter: blur(8px);
+  opacity: 0;
+  transition: all 0.22s ease;
+}
+
 .dock-item:hover {
   transform: translateY(-1px);
   border-color: rgba(0, 212, 255, 0.22);
@@ -1096,6 +730,11 @@ textarea {
 
 .dock-item:hover::before {
   opacity: 1;
+}
+
+.dock-item:hover::after {
+  opacity: 0.6;
+  transform: translateX(-50%) translateY(40%);
 }
 
 .dock-item.is-active {
@@ -1111,10 +750,35 @@ textarea {
     0 14px 32px rgba(0, 212, 255, 0.14);
 }
 
+.dock-item.is-active:hover {
+  transform: scale(1.05);
+}
+
+.dock-item.is-active::after,
+.dock-item.is-active::before {
+  opacity: 0 !important;
+}
+
 .dock-item.is-placeholder,
 .dock-item[disabled] {
+  color: var(--text-muted-text);
   cursor: not-allowed;
   opacity: 0.55;
+}
+
+.dock-item.is-placeholder:hover,
+.dock-item[disabled]:hover {
+  transform: none;
+  border-color: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-muted-text);
+}
+
+.dock-item.is-placeholder:hover::before,
+.dock-item.is-placeholder:hover::after,
+.dock-item[disabled]:hover::before,
+.dock-item[disabled]:hover::after {
+  opacity: 0;
 }
 
 .label-uppercase {
@@ -1126,7 +790,7 @@ textarea {
   line-height: 1;
   letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: var(--text-secondary);
+  color: var(--text-secondary-text);
 }
 
 .btn-primary,
@@ -1166,7 +830,7 @@ textarea {
 .btn-secondary {
   border: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(255, 255, 255, 0.03);
-  color: var(--text-secondary);
+  color: var(--text-secondary-text);
 }
 
 .btn-secondary:hover {
@@ -1184,40 +848,6 @@ textarea {
   transform: none;
 }
 
-.gauge-ring {
-  transform: translateZ(0);
-}
-
-.text-muted {
-  color: var(--text-muted);
-}
-.text-secondary {
-  color: var(--text-secondary);
-}
-.bg-base {
-  background: var(--bg-base);
-}
-.bg-card {
-  background: var(--bg-card);
-}
-.bg-elevated {
-  background: var(--bg-elevated);
-}
 .bg-hover {
   background: var(--bg-hover);
-}
-.border-accent {
-  border-color: var(--border-accent);
-}
-
-@media (max-width: 768px) {
-  .dock-items {
-    gap: 8px;
-  }
-
-  .dock-item {
-    width: 42px;
-    height: 42px;
-    border-radius: 12px;
-  }
 }

--- a/apps/dsa-web/src/index.css
+++ b/apps/dsa-web/src/index.css
@@ -1058,11 +1058,6 @@ textarea {
   );
 }
 
-.dock-items {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
 
 .dock-item {
   position: relative;

--- a/apps/dsa-web/src/pages/BacktestPage.tsx
+++ b/apps/dsa-web/src/pages/BacktestPage.tsx
@@ -47,14 +47,14 @@ function statusBadge(status: string) {
 function boolIcon(value?: boolean | null) {
   if (value === true) return <span className="text-emerald-400">&#10003;</span>;
   if (value === false) return <span className="text-red-400">&#10007;</span>;
-  return <span className="text-muted">--</span>;
+  return <span className="text-muted-text">--</span>;
 }
 
 // ============ Metric Row ============
 
 const MetricRow: React.FC<{ label: string; value: string; accent?: boolean }> = ({ label, value, accent }) => (
   <div className="flex items-center justify-between py-1.5 border-b border-white/5 last:border-0">
-    <span className="text-xs text-secondary">{label}</span>
+    <span className="text-xs text-secondary-text">{label}</span>
     <span className={`text-sm font-mono font-semibold ${accent ? 'text-cyan' : 'text-white'}`}>{value}</span>
   </div>
 );
@@ -74,13 +74,13 @@ const PerformanceCard: React.FC<{ metrics: PerformanceMetrics; title: string }> 
     <MetricRow label="TP Trigger Rate" value={pct(metrics.takeProfitTriggerRate)} />
     <MetricRow label="Avg Days to Hit" value={metrics.avgDaysToFirstHit != null ? metrics.avgDaysToFirstHit.toFixed(1) : '--'} />
     <div className="mt-3 pt-2 border-t border-white/5 flex items-center justify-between">
-      <span className="text-xs text-muted">Evaluations</span>
-      <span className="text-xs text-secondary font-mono">
+      <span className="text-xs text-muted-text">Evaluations</span>
+      <span className="text-xs text-secondary-text font-mono">
         {Number(metrics.completedCount)} / {Number(metrics.totalEvaluations)}
       </span>
     </div>
     <div className="flex items-center justify-between">
-      <span className="text-xs text-muted">W / L / N</span>
+      <span className="text-xs text-muted-text">W / L / N</span>
       <span className="text-xs font-mono">
         <span className="text-emerald-400">{metrics.winCount}</span>
         {' / '}
@@ -96,12 +96,12 @@ const PerformanceCard: React.FC<{ metrics: PerformanceMetrics; title: string }> 
 
 const RunSummary: React.FC<{ data: BacktestRunResponse }> = ({ data }) => (
   <div className="flex items-center gap-4 px-3 py-2 rounded-lg bg-elevated border border-white/5 text-xs font-mono animate-fade-in">
-    <span className="text-secondary">Processed: <span className="text-white">{data.processed}</span></span>
-    <span className="text-secondary">Saved: <span className="text-cyan">{data.saved}</span></span>
-    <span className="text-secondary">Completed: <span className="text-emerald-400">{data.completed}</span></span>
-    <span className="text-secondary">Insufficient: <span className="text-amber-400">{data.insufficient}</span></span>
+    <span className="text-secondary-text">Processed: <span className="text-white">{data.processed}</span></span>
+    <span className="text-secondary-text">Saved: <span className="text-cyan">{data.saved}</span></span>
+    <span className="text-secondary-text">Completed: <span className="text-emerald-400">{data.completed}</span></span>
+    <span className="text-secondary-text">Insufficient: <span className="text-amber-400">{data.insufficient}</span></span>
     {data.errors > 0 && (
-      <span className="text-secondary">Errors: <span className="text-red-400">{data.errors}</span></span>
+      <span className="text-secondary-text">Errors: <span className="text-red-400">{data.errors}</span></span>
     )}
   </div>
 );
@@ -257,7 +257,7 @@ const BacktestPage: React.FC = () => {
             Filter
           </button>
           <div className="flex items-center gap-1 whitespace-nowrap">
-            <span className="text-xs text-muted">Window</span>
+            <span className="text-xs text-muted-text">Window</span>
             <input
               type="number"
               min={1}
@@ -278,7 +278,7 @@ const BacktestPage: React.FC = () => {
               transition-all duration-200 whitespace-nowrap border cursor-pointer
               ${forceRerun
                 ? 'border-cyan/40 bg-cyan/10 text-cyan shadow-[0_0_8px_rgba(0,212,255,0.15)]'
-                : 'border-white/10 bg-transparent text-muted hover:border-white/20 hover:text-secondary'
+                : 'border-white/10 bg-transparent text-muted-text hover:border-white/20 hover:text-secondary-text'
               }
               disabled:opacity-50 disabled:cursor-not-allowed
             `}
@@ -330,7 +330,7 @@ const BacktestPage: React.FC = () => {
             <PerformanceCard metrics={overallPerf} title="Overall Performance" />
           ) : (
             <Card padding="md">
-              <p className="text-xs text-muted text-center py-4">
+              <p className="text-xs text-muted-text text-center py-4">
                 No backtest data yet. Run a backtest to see performance metrics.
               </p>
             </Card>
@@ -349,17 +349,17 @@ const BacktestPage: React.FC = () => {
           {isLoadingResults ? (
             <div className="flex flex-col items-center justify-center h-64">
               <div className="w-10 h-10 border-3 border-cyan/20 border-t-cyan rounded-full animate-spin" />
-              <p className="mt-3 text-secondary text-sm">Loading results...</p>
+              <p className="mt-3 text-secondary-text text-sm">Loading results...</p>
             </div>
           ) : results.length === 0 ? (
             <div className="flex flex-col items-center justify-center h-64 text-center">
               <div className="w-12 h-12 mb-3 rounded-xl bg-elevated flex items-center justify-center">
-                <svg className="w-6 h-6 text-muted" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-6 h-6 text-muted-text" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
                 </svg>
               </div>
               <h3 className="text-base font-medium text-white mb-1.5">No Results</h3>
-              <p className="text-xs text-muted max-w-xs">
+              <p className="text-xs text-muted-text max-w-xs">
                 Run a backtest to evaluate historical analysis accuracy
               </p>
             </div>
@@ -369,15 +369,15 @@ const BacktestPage: React.FC = () => {
                 <table className="w-full text-sm">
                   <thead>
                     <tr className="bg-elevated text-left">
-                      <th className="px-3 py-2.5 text-xs font-medium text-secondary uppercase tracking-wider">Code</th>
-                      <th className="px-3 py-2.5 text-xs font-medium text-secondary uppercase tracking-wider">Date</th>
-                      <th className="px-3 py-2.5 text-xs font-medium text-secondary uppercase tracking-wider">Advice</th>
-                      <th className="px-3 py-2.5 text-xs font-medium text-secondary uppercase tracking-wider">Dir.</th>
-                      <th className="px-3 py-2.5 text-xs font-medium text-secondary uppercase tracking-wider">Outcome</th>
-                      <th className="px-3 py-2.5 text-xs font-medium text-secondary uppercase tracking-wider text-right">Return%</th>
-                      <th className="px-3 py-2.5 text-xs font-medium text-secondary uppercase tracking-wider text-center">SL</th>
-                      <th className="px-3 py-2.5 text-xs font-medium text-secondary uppercase tracking-wider text-center">TP</th>
-                      <th className="px-3 py-2.5 text-xs font-medium text-secondary uppercase tracking-wider">Status</th>
+                      <th className="px-3 py-2.5 text-xs font-medium text-secondary-text uppercase tracking-wider">Code</th>
+                      <th className="px-3 py-2.5 text-xs font-medium text-secondary-text uppercase tracking-wider">Date</th>
+                      <th className="px-3 py-2.5 text-xs font-medium text-secondary-text uppercase tracking-wider">Advice</th>
+                      <th className="px-3 py-2.5 text-xs font-medium text-secondary-text uppercase tracking-wider">Dir.</th>
+                      <th className="px-3 py-2.5 text-xs font-medium text-secondary-text uppercase tracking-wider">Outcome</th>
+                      <th className="px-3 py-2.5 text-xs font-medium text-secondary-text uppercase tracking-wider text-right">Return%</th>
+                      <th className="px-3 py-2.5 text-xs font-medium text-secondary-text uppercase tracking-wider text-center">SL</th>
+                      <th className="px-3 py-2.5 text-xs font-medium text-secondary-text uppercase tracking-wider text-center">TP</th>
+                      <th className="px-3 py-2.5 text-xs font-medium text-secondary-text uppercase tracking-wider">Status</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -387,22 +387,22 @@ const BacktestPage: React.FC = () => {
                         className="border-t border-white/5 hover:bg-hover transition-colors"
                       >
                         <td className="px-3 py-2 font-mono text-cyan text-xs">{row.code}</td>
-                        <td className="px-3 py-2 text-xs text-secondary">{row.analysisDate || '--'}</td>
+                        <td className="px-3 py-2 text-xs text-secondary-text">{row.analysisDate || '--'}</td>
                         <td className="px-3 py-2 text-xs text-white truncate max-w-[140px]" title={row.operationAdvice || ''}>
                           {row.operationAdvice || '--'}
                         </td>
                         <td className="px-3 py-2 text-xs">
                           <span className="flex items-center gap-1">
                             {boolIcon(row.directionCorrect)}
-                            <span className="text-muted">{row.directionExpected || ''}</span>
+                            <span className="text-muted-text">{row.directionExpected || ''}</span>
                           </span>
                         </td>
                         <td className="px-3 py-2">{outcomeBadge(row.outcome)}</td>
                         <td className="px-3 py-2 text-xs font-mono text-right">
                           <span className={
                             row.simulatedReturnPct != null
-                              ? row.simulatedReturnPct > 0 ? 'text-emerald-400' : row.simulatedReturnPct < 0 ? 'text-red-400' : 'text-secondary'
-                              : 'text-muted'
+                              ? row.simulatedReturnPct > 0 ? 'text-emerald-400' : row.simulatedReturnPct < 0 ? 'text-red-400' : 'text-secondary-text'
+                              : 'text-muted-text'
                           }>
                             {pct(row.simulatedReturnPct)}
                           </span>
@@ -425,7 +425,7 @@ const BacktestPage: React.FC = () => {
                 />
               </div>
 
-              <p className="text-xs text-muted text-center mt-2">
+              <p className="text-xs text-muted-text text-center mt-2">
                 {totalResults} result{totalResults !== 1 ? 's' : ''} total
               </p>
             </div>

--- a/apps/dsa-web/src/pages/ChatPage.tsx
+++ b/apps/dsa-web/src/pages/ChatPage.tsx
@@ -3,7 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { agentApi } from '../api/agent';
-import { ApiErrorAlert, ConfirmDialog } from '../components/common';
+import { ApiErrorAlert } from '../components/common';
 import { getParsedApiError } from '../api/error';
 import type { StrategyInfo } from '../api/agent';
 import { historyApi } from '../api/history';
@@ -211,7 +211,7 @@ const ChatPage: React.FC = () => {
     return (
       <button
         onClick={() => toggleThinking(msg.id)}
-        className="flex items-center gap-2 text-xs text-muted hover:text-secondary transition-colors mb-2 w-full text-left"
+        className="flex items-center gap-2 text-xs text-muted-text hover:text-secondary-text transition-colors mb-2 w-full text-left"
       >
         <svg
           className={`w-3 h-3 transition-transform flex-shrink-0 ${isExpanded ? 'rotate-90' : ''}`}
@@ -228,7 +228,7 @@ const ChatPage: React.FC = () => {
         </svg>
         <span className="flex items-center gap-1.5">
           <span className="opacity-60">思考过程</span>
-          <span className="text-muted/50">·</span>
+          <span className="text-muted-text/50">·</span>
           <span className="opacity-50">{summary}</span>
         </span>
       </button>
@@ -240,15 +240,15 @@ const ChatPage: React.FC = () => {
       {steps.map((step, idx) => {
         let icon = '⋯';
         let text = '';
-        let colorClass = 'text-muted';
+        let colorClass = 'text-muted-text';
         if (step.type === 'thinking') {
           icon = '🤔';
           text = step.message || `第 ${step.step} 步：思考`;
-          colorClass = 'text-secondary';
+          colorClass = 'text-secondary-text';
         } else if (step.type === 'tool_start') {
           icon = '⚙️';
           text = `${step.display_name || step.tool}...`;
-          colorClass = 'text-secondary';
+          colorClass = 'text-secondary-text';
         } else if (step.type === 'tool_done') {
           icon = step.success ? '✅' : '❌';
           text = `${step.display_name || step.tool} (${step.duration}s)`;
@@ -277,7 +277,7 @@ const ChatPage: React.FC = () => {
         <span className="text-sm font-medium text-white">历史对话</span>
         <button
           onClick={handleStartNewChat}
-          className="p-1.5 rounded-lg hover:bg-white/10 transition-colors text-secondary hover:text-white"
+          className="p-1.5 rounded-lg hover:bg-white/10 transition-colors text-secondary-text hover:text-white"
           title="新对话"
         >
           <svg
@@ -297,9 +297,9 @@ const ChatPage: React.FC = () => {
       </div>
       <div className="flex-1 overflow-y-auto custom-scrollbar">
         {sessionsLoading ? (
-          <div className="p-4 text-center text-xs text-muted">加载中...</div>
+          <div className="p-4 text-center text-xs text-muted-text">加载中...</div>
         ) : sessions.length === 0 ? (
-          <div className="p-4 text-center text-xs text-muted">暂无历史对话</div>
+          <div className="p-4 text-center text-xs text-muted-text">暂无历史对话</div>
         ) : (
           sessions.map((s) => (
             <button
@@ -310,7 +310,7 @@ const ChatPage: React.FC = () => {
               }`}
             >
               <div className="flex items-center justify-between gap-2">
-                <span className="text-sm text-secondary group-hover:text-white truncate flex-1">
+                <span className="text-sm text-secondary-text group-hover:text-white truncate flex-1">
                   {s.title}
                 </span>
                 <button
@@ -318,7 +318,7 @@ const ChatPage: React.FC = () => {
                     e.stopPropagation();
                     setDeleteConfirmId(s.session_id);
                   }}
-                  className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:bg-white/10 text-muted hover:text-red-400 transition-all flex-shrink-0"
+                  className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:bg-white/10 text-muted-text hover:text-red-400 transition-all flex-shrink-0"
                   title="删除"
                 >
                   <svg
@@ -336,7 +336,7 @@ const ChatPage: React.FC = () => {
                   </svg>
                 </button>
               </div>
-              <div className="text-xs text-muted mt-0.5">
+              <div className="text-xs text-muted-text mt-0.5">
                 {s.message_count} 条消息
                 {s.last_active &&
                   ` · ${new Date(s.last_active).toLocaleDateString('zh-CN', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}`}
@@ -372,16 +372,36 @@ const ChatPage: React.FC = () => {
       )}
 
       {/* Delete confirmation dialog */}
-      <ConfirmDialog
-        isOpen={!!deleteConfirmId}
-        title="删除对话"
-        message="删除后，该对话将不可恢复，确认删除吗？"
-        confirmText="确认删除"
-        cancelText="取消"
-        isDanger={true}
-        onConfirm={confirmDelete}
-        onCancel={() => setDeleteConfirmId(null)}
-      />
+      {deleteConfirmId && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          onClick={() => setDeleteConfirmId(null)}
+        >
+          <div
+            className="bg-elevated border border-white/10 rounded-xl p-6 max-w-sm mx-4 shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 className="text-white font-medium mb-2">删除对话</h3>
+            <p className="text-sm text-secondary-text mb-5">
+              删除后，该对话将不可恢复，确认删除吗？
+            </p>
+            <div className="flex justify-end gap-3">
+              <button
+                onClick={() => setDeleteConfirmId(null)}
+                className="px-4 py-1.5 rounded-lg text-sm text-secondary-text hover:text-white hover:bg-white/5 border border-white/10 transition-colors"
+              >
+                取消
+              </button>
+              <button
+                onClick={confirmDelete}
+                className="px-4 py-1.5 rounded-lg text-sm text-white bg-red-500/80 hover:bg-red-500 transition-colors"
+              >
+                删除
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Main chat area */}
       <div className="flex-1 flex flex-col min-w-0">
@@ -389,7 +409,7 @@ const ChatPage: React.FC = () => {
           <h1 className="text-2xl font-bold text-white mb-2 flex items-center gap-2">
             <button
               onClick={() => setSidebarOpen(true)}
-              className="md:hidden p-1.5 -ml-1 rounded-lg hover:bg-white/10 transition-colors text-secondary hover:text-white"
+              className="md:hidden p-1.5 -ml-1 rounded-lg hover:bg-white/10 transition-colors text-secondary-text hover:text-white"
               title="历史对话"
             >
               <svg
@@ -421,7 +441,7 @@ const ChatPage: React.FC = () => {
             </svg>
             问股
           </h1>
-          <p className="text-secondary text-sm">
+          <p className="text-secondary-text text-sm">
             向 AI 询问个股分析，获取基于策略的交易建议与实时决策报告。
           </p>
           {messages.length > 0 && (
@@ -429,7 +449,7 @@ const ChatPage: React.FC = () => {
               <button
                 type="button"
                 onClick={() => downloadSession(messages)}
-                className="px-3 py-1.5 rounded-lg text-sm text-secondary hover:text-white hover:bg-white/10 border border-white/10 transition-colors flex items-center gap-1.5"
+                className="px-3 py-1.5 rounded-lg text-sm text-secondary-text hover:text-white hover:bg-white/10 border border-white/10 transition-colors flex items-center gap-1.5"
                 title="导出会话为 Markdown 文件"
               >
                 <svg
@@ -470,7 +490,7 @@ const ChatPage: React.FC = () => {
                   }
                 }}
                 disabled={sending}
-                className="px-3 py-1.5 rounded-lg text-sm text-secondary hover:text-white hover:bg-white/10 border border-white/10 transition-colors flex items-center gap-1.5 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="px-3 py-1.5 rounded-lg text-sm text-secondary-text hover:text-white hover:bg-white/10 border border-white/10 transition-colors flex items-center gap-1.5 disabled:opacity-50 disabled:cursor-not-allowed"
                 title="发送到已配置的通知机器人/邮箱"
               >
                 {sending ? (
@@ -528,7 +548,7 @@ const ChatPage: React.FC = () => {
               <div className="h-full flex flex-col items-center justify-center text-center">
                 <div className="w-16 h-16 mb-4 rounded-2xl bg-white/5 flex items-center justify-center">
                   <svg
-                    className="w-8 h-8 text-muted"
+                    className="w-8 h-8 text-muted-text"
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
@@ -544,7 +564,7 @@ const ChatPage: React.FC = () => {
                 <h3 className="text-lg font-medium text-white mb-2">
                   开始问股
                 </h3>
-                <p className="text-sm text-secondary max-w-sm mb-6">
+                <p className="text-sm text-secondary-text max-w-sm mb-6">
                   输入「分析 600519」或「茅台现在能买吗」，AI
                   将调用实时数据工具为您生成决策报告。
                 </p>
@@ -553,7 +573,7 @@ const ChatPage: React.FC = () => {
                     <button
                       key={i}
                       onClick={() => handleQuickQuestion(q)}
-                      className="px-3 py-1.5 rounded-full bg-white/5 border border-white/10 text-sm text-secondary hover:text-white hover:border-cyan/40 hover:bg-cyan/5 transition-all"
+                      className="px-3 py-1.5 rounded-full bg-white/5 border border-white/10 text-sm text-secondary-text hover:text-white hover:border-cyan/40 hover:bg-cyan/5 transition-all"
                     >
                       {q.label}
                     </button>
@@ -579,7 +599,7 @@ const ChatPage: React.FC = () => {
                     className={`max-w-[80%] rounded-2xl px-5 py-3.5 ${
                       msg.role === 'user'
                         ? 'bg-cyan/10 text-white border border-cyan/20 rounded-tr-sm'
-                        : 'bg-white/5 text-secondary border border-white/10 rounded-tl-sm'
+                        : 'bg-white/5 text-secondary-text border border-white/10 rounded-tl-sm'
                     }`}
                   >
                     {msg.role === 'assistant' && msg.strategyName && (
@@ -622,7 +642,7 @@ const ChatPage: React.FC = () => {
                       prose-td:border-white/10 prose-td:px-3 prose-td:py-1.5
                       prose-hr:border-white/10 prose-hr:my-3
                       prose-a:text-cyan prose-a:no-underline hover:prose-a:underline
-                      prose-blockquote:border-cyan/30 prose-blockquote:text-secondary
+                      prose-blockquote:border-cyan/30 prose-blockquote:text-secondary-text
                     "
                       >
                         <Markdown remarkPlugins={[remarkGfm]}>
@@ -652,12 +672,12 @@ const ChatPage: React.FC = () => {
                   AI
                 </div>
                 <div className="bg-white/5 border border-white/10 rounded-2xl rounded-tl-sm px-5 py-4 min-w-[200px] max-w-[80%]">
-                  <div className="flex items-center gap-2.5 text-sm text-secondary">
+                  <div className="flex items-center gap-2.5 text-sm text-secondary-text">
                     <div className="relative w-4 h-4 flex-shrink-0">
                       <div className="absolute inset-0 rounded-full border-2 border-cyan/20" />
                       <div className="absolute inset-0 rounded-full border-2 border-cyan border-t-transparent animate-spin" />
                     </div>
-                    <span className="text-secondary">
+                    <span className="text-secondary-text">
                       {getCurrentStage(progressSteps)}
                     </span>
                   </div>
@@ -675,7 +695,7 @@ const ChatPage: React.FC = () => {
             ) : null}
             {strategies.length > 0 && (
               <div className="mb-3 flex flex-wrap gap-x-5 gap-y-2 items-start">
-                <span className="text-xs text-muted font-medium uppercase tracking-wider flex-shrink-0 mt-1">
+                <span className="text-xs text-muted-text font-medium uppercase tracking-wider flex-shrink-0 mt-1">
                   策略
                 </span>
                 <label className="flex items-center gap-1.5 text-sm cursor-pointer group mt-0.5">
@@ -688,7 +708,7 @@ const ChatPage: React.FC = () => {
                     className="w-3.5 h-3.5 accent-cyan"
                   />
                   <span
-                    className={`transition-colors text-sm ${selectedStrategy === '' ? 'text-white font-medium' : 'text-secondary group-hover:text-white'}`}
+                    className={`transition-colors text-sm ${selectedStrategy === '' ? 'text-white font-medium' : 'text-secondary-text group-hover:text-white'}`}
                   >
                     通用分析
                   </span>
@@ -709,12 +729,12 @@ const ChatPage: React.FC = () => {
                       className="w-3.5 h-3.5 accent-cyan"
                     />
                     <span
-                      className={`transition-colors text-sm ${selectedStrategy === s.id ? 'text-white font-medium' : 'text-secondary group-hover:text-white'}`}
+                      className={`transition-colors text-sm ${selectedStrategy === s.id ? 'text-white font-medium' : 'text-secondary-text group-hover:text-white'}`}
                     >
                       {s.name}
                     </span>
                     {showStrategyDesc === s.id && s.description && (
-                      <div className="absolute left-0 bottom-full mb-2 z-50 w-64 p-2.5 rounded-lg bg-elevated border border-white/10 shadow-xl text-xs text-secondary leading-relaxed pointer-events-none animate-fade-in">
+                      <div className="absolute left-0 bottom-full mb-2 z-50 w-64 p-2.5 rounded-lg bg-elevated border border-white/10 shadow-xl text-xs text-secondary-text leading-relaxed pointer-events-none animate-fade-in">
                         <p className="font-medium text-white mb-1">{s.name}</p>
                         <p>{s.description}</p>
                       </div>

--- a/apps/dsa-web/src/pages/HomePage.tsx
+++ b/apps/dsa-web/src/pages/HomePage.tsx
@@ -412,7 +412,7 @@ const HomePage: React.FC = () => {
           {/* Mobile hamburger */}
           <button
             onClick={() => setSidebarOpen(true)}
-            className="md:hidden p-1.5 -ml-1 rounded-lg hover:bg-white/10 transition-colors text-secondary hover:text-white flex-shrink-0"
+            className="md:hidden p-1.5 -ml-1 rounded-lg hover:bg-white/10 transition-colors text-secondary-text hover:text-white flex-shrink-0"
             title="历史记录"
           >
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -489,7 +489,7 @@ const HomePage: React.FC = () => {
         {isLoadingReport ? (
           <div className="flex flex-col items-center justify-center h-full">
             <div className="w-10 h-10 border-3 border-cyan/20 border-t-cyan rounded-full animate-spin" />
-            <p className="mt-3 text-secondary text-sm">加载报告中...</p>
+            <p className="mt-3 text-secondary-text text-sm">加载报告中...</p>
           </div>
         ) : selectedReport ? (
           <div className="max-w-4xl">
@@ -526,12 +526,12 @@ const HomePage: React.FC = () => {
         ) : (
           <div className="flex flex-col items-center justify-center h-full text-center">
             <div className="w-12 h-12 mb-3 rounded-xl bg-elevated flex items-center justify-center">
-              <svg className="w-6 h-6 text-muted" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-6 h-6 text-muted-text" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
               </svg>
             </div>
             <h3 className="text-base font-medium text-white mb-1.5">开始分析</h3>
-            <p className="text-xs text-muted max-w-xs">
+            <p className="text-xs text-muted-text max-w-xs">
               输入股票代码进行分析，或从左侧选择历史报告查看
             </p>
           </div>

--- a/apps/dsa-web/src/pages/LoginPage.tsx
+++ b/apps/dsa-web/src/pages/LoginPage.tsx
@@ -48,7 +48,7 @@ const LoginPage: React.FC = () => {
         <h1 className="mb-2 text-xl font-semibold text-white">
           {isFirstTime ? '设置初始密码' : '管理员登录'}
         </h1>
-        <p className="mb-6 text-sm text-secondary">
+        <p className="mb-6 text-sm text-secondary-text">
           {isFirstTime
             ? '请设置管理员密码，输入两遍确认'
             : '请输入密码以继续访问'}
@@ -56,7 +56,7 @@ const LoginPage: React.FC = () => {
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label htmlFor="password" className="mb-1 block text-sm font-medium text-secondary">
+            <label htmlFor="password" className="mb-1 block text-sm font-medium text-secondary-text">
               {isFirstTime ? '新密码' : '密码'}
             </label>
             <input
@@ -76,7 +76,7 @@ const LoginPage: React.FC = () => {
             <div>
               <label
                 htmlFor="passwordConfirm"
-                className="mb-1 block text-sm font-medium text-secondary"
+                className="mb-1 block text-sm font-medium text-secondary-text"
               >
                 确认密码
               </label>

--- a/apps/dsa-web/src/pages/NotFoundPage.tsx
+++ b/apps/dsa-web/src/pages/NotFoundPage.tsx
@@ -19,7 +19,7 @@ const NotFoundPage: React.FC = () => {
       </div>
 
       <h1 className="text-2xl font-bold text-white mb-2">页面未找到</h1>
-      <p className="text-muted mb-8">抱歉，您访问的页面不存在或已被移动</p>
+      <p className="text-muted-text mb-8">抱歉，您访问的页面不存在或已被移动</p>
 
       <button 
         type="button"

--- a/apps/dsa-web/src/pages/SettingsPage.tsx
+++ b/apps/dsa-web/src/pages/SettingsPage.tsx
@@ -108,7 +108,7 @@ const SettingsPage: React.FC = () => {
         <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
           <div>
             <h1 className="text-xl font-semibold text-white">系统设置</h1>
-            <p className="text-sm text-secondary">
+            <p className="text-sm text-secondary-text">
               默认使用 .env 中的配置
             </p>
           </div>
@@ -152,7 +152,7 @@ const SettingsPage: React.FC = () => {
       ) : (
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-[260px_1fr]">
           <aside className="rounded-2xl border border-white/8 bg-card/60 p-3 backdrop-blur-sm">
-            <p className="mb-2 text-xs uppercase tracking-wide text-muted">配置分类</p>
+            <p className="mb-2 text-xs uppercase tracking-wide text-muted-text">配置分类</p>
             <div className="space-y-2">
               {categories.map((category) => {
                 const isActive = category.category === activeCategory;
@@ -167,15 +167,15 @@ const SettingsPage: React.FC = () => {
                     className={`w-full rounded-lg border px-3 py-2 text-left transition ${
                       isActive
                         ? 'border-accent bg-cyan/10 text-white'
-                        : 'border-white/8 bg-elevated/40 text-secondary hover:border-white/16 hover:text-white'
+                        : 'border-white/8 bg-elevated/40 text-secondary-text hover:border-white/16 hover:text-white'
                     }`}
                     onClick={() => setActiveCategory(category.category)}
                   >
                     <span className="flex items-center justify-between text-sm font-medium">
                       {title}
-                      <span className="text-xs text-muted">{count}</span>
+                      <span className="text-xs text-muted-text">{count}</span>
                     </span>
-                    {description ? <span className="mt-1 block text-xs text-muted">{description}</span> : null}
+                    {description ? <span className="mt-1 block text-xs text-muted-text">{description}</span> : null}
                   </button>
                 );
               })}
@@ -222,7 +222,7 @@ const SettingsPage: React.FC = () => {
                 />
               ))
             ) : (
-              <div className="rounded-xl border border-white/8 bg-elevated/40 p-5 text-sm text-secondary">
+              <div className="rounded-xl border border-white/8 bg-elevated/40 p-5 text-sm text-secondary-text">
                 当前分类下暂无配置项。
               </div>
             )}

--- a/apps/dsa-web/src/utils/cn.ts
+++ b/apps/dsa-web/src/utils/cn.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/apps/dsa-web/tailwind.config.js
+++ b/apps/dsa-web/tailwind.config.js
@@ -76,6 +76,8 @@ export default {
         base: 'hsl(var(--background))',
         elevated: 'hsl(var(--elevated))',
         hover: 'hsl(var(--hover))',
+        'secondary-bg': 'hsl(var(--secondary))',
+        'muted-bg': 'hsl(var(--muted))',
         'secondary-text': 'hsl(var(--secondary-text))',
         'muted-text': 'hsl(var(--muted-text))',
       },

--- a/apps/dsa-web/tailwind.config.js
+++ b/apps/dsa-web/tailwind.config.js
@@ -1,44 +1,83 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: ['class'],
   content: [
-    "./index.html",
-    "./src/**/*.{js,ts,jsx,tsx}",
+    './index.html',
+    './src/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
+    container: {
+      center: true,
+      padding: '1.5rem',
+      screens: {
+        '2xl': '1400px',
+      },
+    },
     extend: {
       colors: {
-        // 主色调 - 青色
-        'cyan': {
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))',
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))',
+        },
+        cyan: {
           DEFAULT: '#00d4ff',
           dim: '#00a8cc',
           glow: 'rgba(0, 212, 255, 0.4)',
         },
-        // 辅助色 - 紫色
-        'purple': {
+        purple: {
           DEFAULT: '#6f61f1',
           dim: '#533483',
           glow: 'rgba(168, 85, 247, 0.3)',
         },
-        // 状态色
-        'success': '#00ff88',
-        'warning': '#ffaa00',
-        'danger': '#ff4466',
-        // 背景色
-        'base': '#08080c',
-        'card': '#0d0d14',
-        'elevated': '#12121a',
-        'hover': '#1a1a24',
-        // 文字色
-        'primary': '#ffffff',
-        'secondary': '#a0a0b0',
-        'muted': '#606070',
-        // 边框色
-        'border': {
-          dim: 'rgba(255, 255, 255, 0.06)',
-          DEFAULT: 'rgba(255, 255, 255, 0.1)',
-          accent: 'rgba(0, 212, 255, 0.3)',
-          purple: 'rgba(168, 85, 247, 0.3)',
+        success: {
+          DEFAULT: '#00ff88',
+          dim: '#00cc6a',
+          glow: 'rgba(0, 255, 136, 0.3)',
         },
+        warning: {
+          DEFAULT: '#ffaa00',
+          dim: '#cc8800',
+          glow: 'rgba(255, 170, 0, 0.3)',
+        },
+        danger: {
+          DEFAULT: '#ff4466',
+          dim: '#cc3652',
+          glow: 'rgba(255, 68, 102, 0.3)',
+        },
+        base: 'hsl(var(--background))',
+        elevated: 'hsl(var(--elevated))',
+        hover: 'hsl(var(--hover))',
+        'secondary-text': 'hsl(var(--secondary-text))',
+        'muted-text': 'hsl(var(--muted-text))',
       },
       backgroundImage: {
         'gradient-purple-cyan': 'linear-gradient(135deg, rgba(168, 85, 247, 0.2) 0%, rgba(0, 212, 255, 0.1) 100%)',
@@ -46,23 +85,27 @@ export default {
         'gradient-cyan': 'linear-gradient(135deg, #00d4ff 0%, #00a8cc 100%)',
       },
       boxShadow: {
+        'soft-card': '0 18px 48px rgba(3, 8, 20, 0.18)',
         'glow-cyan': '0 0 20px rgba(0, 212, 255, 0.4)',
         'glow-purple': '0 0 20px rgba(168, 85, 247, 0.3)',
         'glow-success': '0 0 20px rgba(0, 255, 136, 0.3)',
         'glow-danger': '0 0 20px rgba(255, 68, 102, 0.3)',
       },
       borderRadius: {
-        'xl': '12px',
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
+        xl: '12px',
         '2xl': '16px',
         '3xl': '20px',
       },
       fontSize: {
-        'xxs': '10px',
-        'label': '11px',
+        xxs: '10px',
+        label: '11px',
       },
       spacing: {
-        '18': '4.5rem',
-        '22': '5.5rem',
+        18: '4.5rem',
+        22: '5.5rem',
       },
       animation: {
         'fade-in': 'fadeIn 0.3s ease-out',
@@ -70,19 +113,24 @@ export default {
         'slide-in-right': 'slideInRight 0.3s ease-out',
         'pulse-glow': 'pulseGlow 2s ease-in-out infinite',
         'spin-slow': 'spin 2s linear infinite',
+        'float-in': 'floatIn 0.45s ease-out',
       },
       keyframes: {
         fadeIn: {
-          'from': { opacity: '0' },
-          'to': { opacity: '1' },
+          from: { opacity: '0' },
+          to: { opacity: '1' },
         },
         slideUp: {
-          'from': { opacity: '0', transform: 'translateY(10px)' },
-          'to': { opacity: '1', transform: 'translateY(0)' },
+          from: { opacity: '0', transform: 'translateY(10px)' },
+          to: { opacity: '1', transform: 'translateY(0)' },
         },
         slideInRight: {
-          'from': { opacity: '0', transform: 'translateX(100%)' },
-          'to': { opacity: '1', transform: 'translateX(0)' },
+          from: { opacity: '0', transform: 'translateX(100%)' },
+          to: { opacity: '1', transform: 'translateX(0)' },
+        },
+        floatIn: {
+          from: { opacity: '0', transform: 'translateY(16px)' },
+          to: { opacity: '1', transform: 'translateY(0)' },
         },
         pulseGlow: {
           '0%, 100%': { boxShadow: '0 0 20px rgba(0, 212, 255, 0.4)' },
@@ -92,4 +140,4 @@ export default {
     },
   },
   plugins: [],
-}
+};

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- 📊 **Web UI Design System** — implemented dual-theme architecture and terminal-inspired atomic UI components
+- 📊 **UI Components Refactoring** — integrated `clsx` and `tailwind-merge` for robust class composition across Web UI
+
 - 🗑️ **History batch deletion** — Web UI now supports multi-selection and batch deletion of analysis history; added `POST /api/v1/history/batch-delete` endpoint and `ConfirmDialog` component.
 - 🔐 **Auth settings API** — new `POST /api/v1/auth/settings` endpoint to enable or disable Web authentication at runtime and set the initial admin password when needed
 
@@ -23,7 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - openclaw Skill 集成指南 — 新增 [docs/openclaw-skill-integration.md](openclaw-skill-integration.md)，说明如何通过 openclaw Skill 调用 DSA API
 - ⚙️ **LLM channel protocol/test UX** — `.env` and Web settings now share the same channel shape (`LLM_CHANNELS` + `LLM_<NAME>_PROTOCOL/BASE_URL/API_KEY/MODELS/ENABLED`); settings page adds per-channel connection testing, primary/fallback/vision model selection, and protocol-aware model prefixing
 
-### Fixed
 - 🔧 **LLM runtime selection guardrails** — YAML 模式下渠道编辑器不再覆盖 `LITELLM_MODEL` / fallback / Vision；系统配置校验补上“全部渠道禁用”后的运行时来源检查，并修复 `vertexai/...` 这类协议别名模型被重复加前缀的问题
 - 🐛 **P0 基本面聚合稳定性修复** (#614) — 修复 `get_stock_info` 板块语义回归（新增 `belong_boards` 并保留 `boards` 兼容别名）、引入基本面上下文精简返回以控制 token、为基本面缓存增加最大条目淘汰，并补齐 ETF 总体状态聚合与 NaN 板块字段过滤，保证 fail-open 与最小入侵。
 - 🔧 **GitHub Actions 搜索引擎环境变量补充** — 工作流新增 `MINIMAX_API_KEYS`、`BRAVE_API_KEYS`、`SEARXNG_BASE_URLS` 环境变量映射，使 GitHub Actions 用户可配置 MiniMax、Brave、SearXNG 搜索服务（此前 v3.5.0 已添加 provider 实现但缺少工作流配置）


### PR DESCRIPTION
## PR Type

- [x] fix
- [x] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

本 PR 对齐 Issue #602 中的 "[PR 4] 设计系统与原子组件库" 拆分目标，落地 `apps/dsa-web` 的 design token 与 common 原子组件基础层，为后续 `Shell`、主题切换和页面级重绘提供统一底座。

当前 Web UI 主要存在的问题：
* `components/common` 中的基础组件能力不完整（如 `Input`、`EmptyState` 等缺失），导致页面层重复拼装样式。
* 现有组件的 class 组合方式分散，样式覆盖依赖手写字符串拼接，易产生冲突。
* 缺少统一的语义化 token 约束（颜色、阴影、圆角等），不利于渐进式双主题扩展。
* 全局样式与终端风格 UI utility 未沉淀为统一规范。
* 历史代码存在为了妥协而将 `secondary` 变体映射为文本颜色的语义反转技术债。
* 多层级 `Drawer` 嵌套时的全局 body 滚动锁定机制存在缺陷。

## Scope Of Change

* **`apps/dsa-web/tailwind.config.js`**
  * 补充语义化颜色、阴影、圆角、spacing、animation 与 keyframes 配置。
  * 纠正 Tailwind 颜色语义反转：将 `secondary` 与 `muted` 恢复为标准的背景色语义映射。
* **`apps/dsa-web/src/index.css`**
  * 重整全局 token 与基础样式，补充 terminal-inspired 的 utility（card, input, button, badge, scrollbar 等）。
  * 彻底移除 RGBA 硬编码，全面替换为 `hsl(var(--card))` 等响应式主题变量，确保双主题扩展能力。
  * 清理重复的 `@keyframes` 动画声明，完全拥抱 Tailwind 4 的内置能力。
* **`apps/dsa-web/src/components/common/*`**
  * **升级组件**：`Button`、`Badge`、`Card`、`Collapsible`、`Drawer`、`Loading`、`Pagination`、`ScoreGauge`、`Select`。
  * **新增组件**：`AppPage`、`EmptyState`、`InlineAlert`、`Input`、`PageHeader`、`SectionCard`、`StatCard`、`StickyActionBar`、`ToastViewport`、`Toolbar`。
  * **修复缺陷**：修复 `Badge` 因重写调色板导致投影失效的问题；增强 `Drawer` 稳健性，引入 `activeDrawerCount` 状态机彻底解决滚动锁定 Bug。
* **`apps/dsa-web/src/utils/cn.ts`**
  * 新增统一的 class merge helper（结合 `clsx` 与 `tailwind-merge`）。
- `apps/dsa-web/package.json`
  - 引入 `clsx` 与 `tailwind-merge` 依赖，支撑组件层样式组合能力。
- `apps/dsa-web/src/components/settings/SettingsAlert.tsx`
  - 小幅适配新的公共组件与样式体系。
* **批量重构**
  * 利用脚本完成全站 30 余个文件、152 处旧类名（如 `text-secondary` -> `text-secondary-text`）的批量安全替换，消除了长期的技术债。
* **`docs/CHANGELOG.md`**
  * 同步记录变更。对用户体验几乎没有影响，因此未变更`README.md`;

## Issue Link

- 没有直接可以关闭的Issue；
- 有规划相关 Issue， Refs #602

## Verification Commands And Results

```bash
npm --prefix apps/dsa-web run build
npm --prefix apps/dsa-web run lint
```

关键输出/结论：
构建与 Lint 均已通过，Web UI 正常展示，控制台无异常报错。UI 交互层面，多重 Drawer 的开闭能够按照正确时机锁定与解锁 body 的 `overflow` 属性。终端风格组件已全面接入 HSL Token 响应。

## Compatibility And Risk

兼容性影响：旧的 `text-secondary` 和 `text-muted` 已被全局安全重构为 `text-secondary-text` 和 `text-muted-text`。
潜在风险：由于组件使用 `cn` 函数处理样式层叠，部分未适配的边缘场景可能需要后续微调。风险极低。

## Rollback Plan

执行 `git revert -m 1 <merge_commit_sha>` 或通过 GitHub UI 直接执行 Revert 此 PR。

## Checklist

- [x] 我已确认本 PR 有明确动机和业务价值
- [x] 我已提供可复现的验证命令与结果
- [x] 我已评估兼容性与风险
- [x] 我已提供回滚方案
- [x] 若涉及用户可见变更，我已同步更新 `docs/CHANGELOG.md`

--------
## 补充说明
在最初提交基础组件层后，我们执行了一轮深度的架构级 Code Review。主要解决了以下阻碍“真正双主题化”和“组件稳健性”的遗留问题：
- 1. 规范设计令牌 (Design Tokens)：修复了历史代码为了妥协而将 secondary 变体映射为文本颜色的问题，现在 Token 映射严格符合 Tailwind
  约定。
 - 2. 清除硬编码：新引入的终端拟态组件（Terminal / Glass UI）已实现 100% 依赖 HSL 变量，移除了所有固定透明度的色值硬编码。
 - 3. 无障碍与边界情况 (A11y & Edge Cases)：修复了多层级 Drawer 嵌套时的全局 body 滚动锁定问题，进一步增强了底层基建的可靠性。
 